### PR TITLE
add tealium script to default layout

### DIFF
--- a/layouts/drc/default.hbs
+++ b/layouts/drc/default.hbs
@@ -19,6 +19,7 @@
 <script src="{{ assets.js_drc_url }}"></script>
 
 [+ drc/common/ga.hbs +]
+[+ drc/common/tealium.hbs +]
 [+ drc/common/survey.hbs +]
 [+ drc/common/remarketing.hbs +]
 


### PR DESCRIPTION
Was this accidentally left out of the default layout?
You need this for SiteCatalyst.
