### PR TITLE
make the prev/next links a hair larger

### DIFF
--- a/assets/less/drc/components/narrow-sidebar.less
+++ b/assets/less/drc/components/narrow-sidebar.less
@@ -72,6 +72,7 @@
                 width: 50%;
 
                 a {
+                    font-size: 18px;
                     font-weight: 600;
                 }
 


### PR DESCRIPTION
To fix #27
### Before:

![before](https://cloud.githubusercontent.com/assets/3018940/8242856/09992504-15d8-11e5-90f0-6f6c0bc22dd2.png)
### After:

![after](https://cloud.githubusercontent.com/assets/3018940/8242866/13c8070c-15d8-11e5-9245-698a0804d3b5.png)
