### PR TITLE
Don't double-escape next and previous link titles.

### DIFF
--- a/layouts/drc/narrow-sidebar.hbs
+++ b/layouts/drc/narrow-sidebar.hbs
@@ -30,12 +30,12 @@
             <div class="serial-links clearfix">
                 <div class="previous">
                     {{#if envelope.previous}}
-                    <a href="{{ envelope.previous.url }}">{{ envelope.previous.title }}</a>
+                    <a href="{{ envelope.previous.url }}">{{{ envelope.previous.title }}}</a>
                     {{/if}}
                 </div>
                 <div class="next">
                     {{#if envelope.next}}
-                    <a href="{{ envelope.next.url }}">{{ envelope.next.title }}</a>
+                    <a href="{{ envelope.next.url }}">{{{ envelope.next.title }}}</a>
                     {{/if}}
                 </div>
             </div>


### PR DESCRIPTION
Handlebars and Sphinx were both HTML-escaping the next and previous link titles. Tell Handlebars to treat them as trusted raw HTML.

This will deal with #38 in the current system.
