### PR TITLE
Reorder rewrites

### DIFF
--- a/config/rewrites.json
+++ b/config/rewrites.json
@@ -1,14 +1,16 @@
 {
     "developer.rackspace.com": [
         {
-            "description": "Force trailing slash",
-            "from": "^/(.*[^/])$",
-            "to": "/$1/",
+            "from": "^\/docs\/user-guides\/?$",
+            "to": "/docs/user-guides/infrastructure/",
+            "rewrite": false,
             "status": 301
         },
         {
-            "from": "^\/docs\/user-guides\/?$",
-            "to": "/docs/user-guides/infrastructure/",
+            "description": "Force trailing slash",
+            "from": "^/(.*[^/])$",
+            "to": "/$1/",
+            "rewrite": false,
             "status": 301
         }
     ]


### PR DESCRIPTION
We want the trailing slash redirect to be the very last one, to avoid multiple consecutive redirects that are bad for SEO
