### PR TITLE
Enable language toggles for CDN and Cloud Networks

### DIFF
--- a/assets/js/drc/pages/docs.js
+++ b/assets/js/drc/pages/docs.js
@@ -13,7 +13,8 @@
     '/docs/cloud-queues': [ 'go', 'java', '.net', 'php','python','ruby','shell' ],
     '/docs/cloud-monitoring': [ 'go', 'java', '.net', 'php','python','ruby','shell' ],
     '/docs/cloud-identity': [ 'go', 'java', '.net', 'php','python','ruby','shell' ],
-    '/docs/orchestration': [ 'go','node.js','php','ruby','shell' ]
+    '/docs/orchestration': [ 'go', 'node.js', 'php', 'ruby', 'shell' ],
+    '/docs/cdn': [ 'go', 'java', '.net', 'node.js', 'php', 'python', 'ruby', 'shell' ]
   };
 
   var cookieName = 'devsite-language';

--- a/assets/js/drc/pages/docs.js
+++ b/assets/js/drc/pages/docs.js
@@ -14,7 +14,8 @@
     '/docs/cloud-monitoring': [ 'go', 'java', '.net', 'php','python','ruby','shell' ],
     '/docs/cloud-identity': [ 'go', 'java', '.net', 'php','python','ruby','shell' ],
     '/docs/orchestration': [ 'go', 'node.js', 'php', 'ruby', 'shell' ],
-    '/docs/cdn': [ 'go', 'java', '.net', 'node.js', 'php', 'python', 'ruby', 'shell' ]
+    '/docs/cdn': [ 'go', 'java', '.net', 'node.js', 'php', 'python', 'ruby', 'shell' ],
+    '/docs/cloud-networks': [ 'go', 'java', 'node.js', 'php', 'ruby', 'shell' ]
   };
 
   var cookieName = 'devsite-language';


### PR DESCRIPTION
The CDN and Cloud Networks quickstart guides are missing the "I'm coding in..." banner.
