### PR TITLE
Add the CLB docs.

### DIFF
--- a/config/content.json
+++ b/config/content.json
@@ -3,7 +3,8 @@
         "content": {
             "/": "https://github.com/rackerlabs/docs-developer-blog/",
             "/docs/": "https://github.com/rackerlabs/docs-quickstart/",
-            "/docs/user-guides/infrastructure/": "https://github.com/rackerlabs/docs-core-infra-user-guide/"
+            "/docs/user-guides/infrastructure/": "https://github.com/rackerlabs/docs-core-infra-user-guide/",
+            "/docs/cloud-load-balancers/": "https://github.com/rackerlabs/docs-cloud-load-balancers/"
         },
         "proxy": {
             "/favicon.ico": "https://8d8dcdd952aa2708c2ff-519cda130c91226e76017ae910bdb276.ssl.cf1.rackcdn.com/favicon-aa186bee158ecea4c9b6a98e2ceec3141b6b7d8d94dcb71731ba112e2b17b1db.ico"


### PR DESCRIPTION
This adds [docs-cloud-load-balancers](https://github.com/rackerlabs/docs-cloud-load-balancers) to our staging server at the path `/docs/cloud-load-balancers/`. It's the next step in rackerlabs/nexus-control#53.

_/me is very careful to submit this to staging and not master_
