### PR TITLE
Map rack CLI documentation

### DIFF
--- a/config/content.json
+++ b/config/content.json
@@ -4,7 +4,8 @@
             "/": "https://github.com/rackerlabs/docs-developer-blog/",
             "/docs/": "https://github.com/rackerlabs/docs-quickstart/",
             "/docs/user-guides/infrastructure/": "https://github.com/rackerlabs/docs-core-infra-user-guide/",
-            "/docs/user-guides/cloud-load-balancers/": "https://github.com/rackerlabs/docs-cloud-load-balancers/"
+            "/docs/user-guides/cloud-load-balancers/": "https://github.com/rackerlabs/docs-cloud-load-balancers/",
+            "/docs/user-guides/rack-cli/": "https://github.com/rackspace/rack"
         },
         "proxy": {
             "/favicon.ico": "https://8d8dcdd952aa2708c2ff-519cda130c91226e76017ae910bdb276.ssl.cf1.rackcdn.com/favicon-aa186bee158ecea4c9b6a98e2ceec3141b6b7d8d94dcb71731ba112e2b17b1db.ico"


### PR DESCRIPTION
I just submitted a manual preparer build of the Rack CLI to staging; this will route the documents so we can preview them and find style issues without having to mess with deconst/integrated.

I'm mapping them under `/docs/user-guides/rack-cli` for now. We can always move it to a better place before shipping to production.

/cc @kenperkins, @ktbartholomew 
