### PR TITLE
Route /docs/rack-cli to the rack-cli documentation.

### DIFF
--- a/config/content.json
+++ b/config/content.json
@@ -3,7 +3,8 @@
         "content": {
             "/": "https://github.com/rackerlabs/docs-developer-blog/",
             "/docs/": "https://github.com/rackerlabs/docs-quickstart/",
-            "/docs/user-guides/infrastructure/": "https://github.com/rackerlabs/docs-core-infra-user-guide/"
+            "/docs/user-guides/infrastructure/": "https://github.com/rackerlabs/docs-core-infra-user-guide/",
+            "/docs/rack-cli/": "https://github.com/rackspace/rack/"
         },
         "proxy": {
             "/favicon.ico": "https://8d8dcdd952aa2708c2ff-519cda130c91226e76017ae910bdb276.ssl.cf1.rackcdn.com/favicon-aa186bee158ecea4c9b6a98e2ceec3141b6b7d8d94dcb71731ba112e2b17b1db.ico"

--- a/config/routes.json
+++ b/config/routes.json
@@ -8,6 +8,7 @@
             "^/blog/categories": "default.html",
             "^/docs": "docs_page.html",
             "^/docs/user-guides/infrastructure/": "user-guides.html",
+            "^/docs/rack-cli/": "user-guides.html",
             "^/sdks": "sdks.html",
             "\\.xml$": "feed.xml"
         }


### PR DESCRIPTION
This ports the work from #63, #64, and #67 from staging to production.
