### PR TITLE
Show .NET in the Cloud Networks QuickStart

### DIFF
--- a/assets/js/drc/pages/docs.js
+++ b/assets/js/drc/pages/docs.js
@@ -15,7 +15,7 @@
     '/docs/cloud-identity': [ 'go', 'java', '.net', 'php','python','ruby','shell' ],
     '/docs/orchestration': [ 'go', 'node.js', 'php', 'ruby', 'shell' ],
     '/docs/cdn': [ 'go', 'java', '.net', 'node.js', 'php', 'python', 'ruby', 'shell' ],
-    '/docs/cloud-networks': [ 'go', 'java', 'node.js', 'php', 'ruby', 'shell' ]
+    '/docs/cloud-networks': [ 'go', 'java', '.net', 'node.js', 'php', 'ruby', 'shell' ]
   };
 
   var cookieName = 'devsite-language';


### PR DESCRIPTION
Rackspace.NET now supports Cloud Networks.
