### PR TITLE
Make build the default grunt task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -190,4 +190,6 @@ module.exports = function(grunt) {
         'deconst_assets:css_js'
     ]);
 
+    grunt.registerTask('default', ['build']);
+
 };


### PR DESCRIPTION
This lets you run the asset preparer by just invoking `grunt`.

I'm working on preparing assets automatically during client-side builds, and I'd rather not hardcode an arbitrary grunt task to prepare the control repository's assets. This lets the client's logic become "run the `quay.io/deconst/preparer-asset` container on the control repo" and keeps me from having to explicitly configure things like a `grunt` CLI invocation.
