### PR TITLE
fix the theme colors to what they really should be

### DIFF
--- a/assets/src/css/less/components/cards.less
+++ b/assets/src/css/less/components/cards.less
@@ -22,6 +22,10 @@
         border-top-color: @theme-red;
     }
 
+    &.teal {
+        border-top-color: @theme-teal;
+    }
+
     &.purple {
         border-top-color: @theme-purple;
     }

--- a/assets/src/css/less/layouts/docs-home.less
+++ b/assets/src/css/less/layouts/docs-home.less
@@ -155,14 +155,14 @@ body.docs-home {
                 }
 
                 &.storage .indicator {
-                    background: @theme-red;
-                    border-color: @theme-red;
+                    background: @theme-yellow;
+                    border-color: @theme-yellow;
                     color: white;
                 }
 
                 &.data .indicator {
-                    background: @theme-yellow;
-                    border-color: @theme-yellow;
+                    background: @theme-teal;
+                    border-color: @theme-teal;
                     color: white;
                 }
 

--- a/assets/src/css/less/variables.less
+++ b/assets/src/css/less/variables.less
@@ -27,6 +27,7 @@
 @theme-green: #1abc9c;
 @theme-red: #e74c3c;
 @theme-yellow: #efc75e;
+@theme-teal: #0dafcc;
 @theme-purple: #8e708e;
 @theme-pink: #d86c90;
 


### PR DESCRIPTION
This will create a color mismatch for just a little bit until I change the classnames being used in docs-quickstart.
