### PR TITLE
Corrected path to Metrics source repository.

### DIFF
--- a/config/content.json
+++ b/config/content.json
@@ -20,7 +20,7 @@
             "/docs/cloud-autoscale/v1/developer-guide/": "https://github.com/rackerlabs/otter/",
             "/docs/cloud-servers/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-servers/",
             "/docs/cloud-files/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-files/",
-            "/docs/cloud-metrics/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-databases/",
+            "/docs/cloud-metrics/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-metrics/",
             "/docs/cloud-identity/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-identity-2.0/",
             "/docs/cloud-monitoring/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-monitoring/"
         },


### PR DESCRIPTION
The content.json specification for Metrics was pointing to the databases repository.
