### PR TITLE
Add Cassandra to the databases sidebar.

### DIFF
--- a/templates/developer.rackspace.com/databases-index.html
+++ b/templates/developer.rackspace.com/databases-index.html
@@ -42,6 +42,9 @@
     <li data-drc-scroll-indicator="Redis" data-use-attribute="id">
       <a href="#Redis">Redis</a>
     </li>
+    <li data-drc-scroll-indicator="Cassandra" data-use-attribute="id">
+      <a href="#Cassandra">Cassandra</a>
+    </li>
     <li data-drc-scroll-indicator="Hadoop" data-use-attribute="id">
       <a href="#Hadoop">Hadoop</a>
     </li>


### PR DESCRIPTION
This adds Cassandra to the side navigation on the databases/ page.

/cc rackerlabs/docs-developer-blog#104.
