### PR TITLE
Don't serve index as text/plain

### DIFF
--- a/config/routes.json
+++ b/config/routes.json
@@ -43,8 +43,7 @@
         "^/docs": "docs-home.html",
         "^/docs/.+?": "docs-single.html",
         "^/blog/.+?": "docs-single.html",
-        "\\.txt$": "robots.txt",
-        "^/$": "robots.txt"
+        "\\.txt$": "robots.txt"
       }
     }
 }


### PR DESCRIPTION
A smarter person might have written the placeholder as an actual HTML file to make this easier. Ah well :wink:
