### PR TITLE
Redirects for runcarina and www. variants.

### DIFF
--- a/config/rewrites.json
+++ b/config/rewrites.json
@@ -62,5 +62,45 @@
             "rewrite": false,
             "status": 301
         }
+    ],
+    "www.developer.rackspace.com": [
+      {
+        "from": "^(.*)$",
+        "to": "$1",
+        "toProtocol": "https",
+        "toHostname": "developer.rackspace.com",
+        "rewrite": false,
+        "status": 301
+      }
+    ],
+    "www.getcarina.com": [
+      {
+        "from": "^(.*)$",
+        "to": "$1",
+        "toProtocol": "https",
+        "toHostname": "getcarina.com",
+        "rewrite": false,
+        "status": 301
+      }
+    ],
+    "runcarina.com": [
+      {
+        "from": "^(.*)$",
+        "to": "$1",
+        "toProtocol": "https",
+        "toHostname": "getcarina.com",
+        "rewrite": false,
+        "status": 301
+      }
+    ],
+    "www.runcarina.com": [
+      {
+        "from": "^(.*)$",
+        "to": "$1",
+        "toProtocol": "https",
+        "toHostname": "getcarina.com",
+        "rewrite": false,
+        "status": 301
+      }
     ]
 }


### PR DESCRIPTION
This requires deconst/presenter#74 to be :shipit:'d.
