### PR TITLE
Fixing missing trailing slash

### DIFF
--- a/templates/getcarina.com/_includes/site-header.html
+++ b/templates/getcarina.com/_includes/site-header.html
@@ -21,7 +21,7 @@
         <a href="/">Home</a>
       </li>
       <li{% if deconst.request.path.match('/docs') %} class="active"{% endif %}>
-        <a href="/docs"><span class="long">Documentation</span><span class="short">Docs</span></a>
+        <a href="/docs/"><span class="long">Documentation</span><span class="short">Docs</span></a>
       </li>
       <li>
         <a href="https://community.getcarina.com/">Community</a>


### PR DESCRIPTION
Fixes a 301 redirect on all docs links on carina from the header.
