### PR TITLE
optionally collapse sections in super-long documents

### DIFF
--- a/assets/src/css/less/layouts/sidebar-left.less
+++ b/assets/src/css/less/layouts/sidebar-left.less
@@ -63,6 +63,7 @@
         }
     }
 
+    // This is super-brittle and awful, but Sphinx does what it does ¯\_(ツ)_/¯
     .content > .docs-section > .section > .toctree-wrapper > .collapsible-section {
       display: none;
 

--- a/assets/src/css/less/layouts/sidebar-left.less
+++ b/assets/src/css/less/layouts/sidebar-left.less
@@ -62,4 +62,66 @@
             margin-left: calc(40% - 480px);
         }
     }
+
+    .content > .docs-section > .section > .toctree-wrapper > .collapsible-section {
+      display: none;
+
+      &.open {
+        display: block;
+      }
+    }
+
+    .collapsible-section-toggle {
+      border-bottom: solid 1px shade(white, 10%);
+      cursor: pointer;
+
+      .toggle {
+        .fa();
+        color: tint(@text-color, 50%);
+        font-size: percentage((12/14));
+        height: 32px;
+        text-align: center;
+        text-decoration: none;
+        line-height: 32px;
+        vertical-align: top;
+
+        &:before {
+          color: @link-color;
+          content: @fa-var-minus;
+          margin-right: 0.5em;
+          vertical-align: middle;
+        }
+      }
+
+      &.show {
+        h2 {
+          display: inline-block;
+          font-size: percentage((20/14));
+        }
+
+        .toggle {
+          color: transparent;
+          font-size: percentage((14/14));
+          height: 50px;
+          line-height: 50px;
+          overflow: hidden;
+          width: 25px;
+
+          &:before {
+            color: @link-color;
+            content: @fa-var-plus;
+          }
+        }
+      }
+
+      h2 {
+        display: none;
+        line-height: 50px;
+        margin: 0;
+
+        .headerlink {
+          display: none;
+        }
+      }
+    }
 }

--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -1,3 +1,5 @@
+global.$ = global.jQuery = require('jquery');
+
 var angular = require('angular');
 
 var moduleName = 'drc.app';
@@ -6,6 +8,7 @@ module.exports = moduleName;
 angular.module(moduleName, [
     require('./components/code-sample'),
     require('./components/code-sample-parent'),
+    require('./components/collapsible-section'),
     require('./components/database-jump'),
     require('./components/dropdown-toggle'),
     require('./components/flex-height'),

--- a/assets/src/js/components/collapsible-section.js
+++ b/assets/src/js/components/collapsible-section.js
@@ -1,0 +1,51 @@
+var $ = require('jquery');
+var angular = require('angular');
+
+module.exports = angular.module('drc.components.collapsible-section', [])
+.directive('collapsibleSection', ['$rootScope', '$sce', function ($rootScope, $sce) {
+    return {
+        scope: true,
+        restrict: 'C',
+        controller: ['$scope', '$element', '$attrs', '$compile', function ($scope, $element, $attrs, $compile) {
+
+          // Compile a toggle element and add it before the section
+          $scope.init = function () {
+            var toggleTemplate = '<div class="collapsible-section-toggle" data-ng-click="toggle()" data-ng-class="{\'show\': !isOpen()}"><a class="toggle" href="">collapse section</a> <h2 data-ng-bind-html="title"></h2></div>';
+            var output = $compile(toggleTemplate)($scope);
+
+            $element.before(output);
+          };
+        }],
+        link: function ($scope, $element, $attrs) {
+          $scope.title = $sce.trustAsHtml(
+            $element.find('.collapsible-section-title').html()
+          );
+
+          if(window.location.hash == '#' + $element.attr('id')) {
+            $element.addClass('open');
+
+            setTimeout(function () {
+              $rootScope.$emit('$drcFlexHeight.flexHeight');
+              window.scrollTo(0, $element.offset().top);
+            }, 20);
+
+          }
+
+          $scope.toggle = function () {
+            $element.toggleClass('open');
+
+            // Give the browser a little time to paint so the flexHeight
+            // calculations are correct.
+            setTimeout(function () {
+              $rootScope.$emit('$drcFlexHeight.flexHeight');
+            }, 20);
+          };
+
+          $scope.isOpen = function () {
+            return $element.hasClass('open');
+          };
+
+          $scope.init();
+        }
+    };
+}]).name;

--- a/assets/src/js/components/flex-height.js
+++ b/assets/src/js/components/flex-height.js
@@ -4,12 +4,8 @@
 var $ = require('jquery');
 var angular = require('angular');
 
-
-var moduleName = 'drc.components.flex-height';
-module.exports = moduleName;
-
-angular.module(moduleName, [])
-.directive('drcFlexHeight', function () {
+module.exports = angular.module('drc.components.flex-height', [])
+.directive('drcFlexHeight', ['$rootScope', function ($rootScope) {
     return {
         link: function ($scope, $element, $attrs) {
             $element = $($element);
@@ -29,8 +25,9 @@ angular.module(moduleName, [])
             };
 
             $(window).on('scroll resize', flexHeight.bind(this));
+            $rootScope.$on('$drcFlexHeight.flexHeight', flexHeight.bind(this));
 
             flexHeight();
         }
     };
-});
+}]).name;

--- a/plugins/developer.rackspace.com/deconst-nav/filters/collapse-sections.js
+++ b/plugins/developer.rackspace.com/deconst-nav/filters/collapse-sections.js
@@ -1,0 +1,21 @@
+module.exports = [
+    'collapseSections',
+    function (input) {
+        var cheerio = require('cheerio');
+        var $ = cheerio.load(input);
+
+        var mainToctree = $('.toctree-wrapper').first();
+
+        mainToctree.children('.section').each(function (index, element) {
+          $(element).addClass('collapsible-section');
+          $(element).children('h1,h2,h3').first().addClass('collapsible-section-title');
+
+          if(index === 0) {
+            $(element).addClass('open');
+          }
+        });
+
+        return $.html();
+    },
+    false
+];

--- a/plugins/developer.rackspace.com/deconst-nav/index.js
+++ b/plugins/developer.rackspace.com/deconst-nav/index.js
@@ -1,6 +1,7 @@
 module.exports = {
     templateFilters: [
         require('./filters/add-scroll-indicators'),
+        require('./filters/collapse-sections'),
         require('./filters/limit-list-depth'),
         require('./filters/prune-root'),
         require('./filters/remove-anchor-links'),

--- a/templates/developer.rackspace.com/docs-singlepage.html
+++ b/templates/developer.rackspace.com/docs-singlepage.html
@@ -52,6 +52,11 @@
 
 {% block content %}
     <section class="docs-section">
-        {{ deconst.content.envelope.body }}
+      {% set output = deconst.content.envelope.body %}
+      {% if deconst.content.envelope.meta.collapseSections == 'true' %}
+        {% set output = output|collapseSections %}
+      {% endif %}
+
+      {{ output }}
     </section>
 {% endblock %}


### PR DESCRIPTION
This turns the high-level sections of a Sphinx single-page document into collapsible elements to allow underpowered browsers to load the page without crashing. If the hash portion of the URL matches the ID attribute of the collapsed section, it will be automatically expanded on page load.

![image](https://cloud.githubusercontent.com/assets/3018940/11228354/94c529fc-8d51-11e5-86cb-c06c3c55f8d6.png)
### Caveats
- It looks like there are some discrepancies in what's being used for hyperlinks and what the actual section IDs are, though.
- There are inconsistencies in how sections are arranged/nested in certain documents, which will yield unwanted visual results
- Content writers must enable this behavior on a per-document basis by adding the following field to the top of the document: `:collapseSections: true`
