### PR TITLE
Bump the grunt-deconst-assets version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-contrib-less": "^1.0.1",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-deconst-assets": "^0.1.2",
+    "grunt-deconst-assets": "^0.2.0",
     "jquery": "^2.1.4",
     "lodash": "^3.9.3"
   },


### PR DESCRIPTION
This will include deconst/grunt-deconst-assets#3 and let us make _any_ change to the control repository without requiring administrators to run anything in Ansible.
