### PR TITLE
Corrected version in Metrics URI

### DIFF
--- a/config/content.json
+++ b/config/content.json
@@ -21,7 +21,7 @@
             "/docs/autoscale/v1/developer-guide/": "https://github.com/rackerlabs/otter/",
             "/docs/cloud-servers/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-servers/",
             "/docs/cloud-files/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-files/",
-            "/docs/metrics/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-metrics/",
+            "/docs/metrics/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-metrics/",
             "/docs/cloud-identity/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-identity-2.0/",
             "/docs/cloud-monitoring/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-monitoring/"
         },

--- a/config/routes.json
+++ b/config/routes.json
@@ -29,7 +29,7 @@
             "^/docs/autoscale/v1/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-servers/v2/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-files/v1/developer-guide": "docs-singlepage.html",
-            "^/docs/metrics/v1/developer-guide": "docs-singlepage.html",
+            "^/docs/metrics/v2/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-identity/v2/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-monitoring/v1/developer-guide": "docs-singlepage.html",
             "^/docs/rack-cli/": "rack-cli.html",


### PR DESCRIPTION
Metrics URI set to v1, but Metrics API contract version is 2.0. 
Updating configuration files with correct version.
