### PR TITLE
Only invoke Grunt if environment variables are set.

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -31,6 +31,4 @@ fi
 if [ "${PUBLISH}" = "true" ]; then
   npm install
   grunt build
-else
-  # Verify control repository contents
 fi

--- a/script/cibuild
+++ b/script/cibuild
@@ -4,17 +4,21 @@
 
 set -euo pipefail
 
+PUBLISH="false"
+
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
   case ${TRAVIS_BRANCH} in
     master)
       echo "Submitting to production."
       export CONTENT_STORE_URL=https://developer.rackspace.com:9000/
       export CONTENT_STORE_APIKEY=${PROD1}${PROD2}${PROD3}
+      export PUBLISH="true"
       ;;
     staging)
       echo "Submitting to staging."
       export CONTENT_STORE_URL=http://staging.developer.rackspace.com:8000/
       export CONTENT_STORE_APIKEY=${STAGE1}${STAGE2}${STAGE3}
+      export PUBLISH="true"
       ;;
     *)
       echo "Not submitting ${TRAVIS_BRANCH} anywhere."
@@ -24,5 +28,9 @@ else
   echo "Not submitting pull request build anywhere."
 fi
 
-npm install
-grunt build
+if [ "${PUBLISH}" = "true" ]; then
+  npm install
+  grunt build
+else
+  # Verify control repository contents
+fi


### PR DESCRIPTION
There's no benefit to invoking Grunt if the assets aren't going to be published anywhere. In this case it was actually causing push builds to fail, too.

Fixes #263.
