### PR TITLE
Adds redirects from api.rackspace.com (don't merge until 1/4)

### DIFF
--- a/config/rewrites.json
+++ b/config/rewrites.json
@@ -153,5 +153,118 @@
             "rewrite": false,
             "status": 302
         }
+    ],
+    "api.rackspace.com": [
+        {  "description": "Redirect root traffic to developer.rs.com/docs/",
+            "from": "^\\/$",
+            "to": "/docs/",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Servers redirect",
+            "from": "^\\/api-ref.html$",
+            "to": "/docs/cloud-servers/v2/developer-guide/#api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Auto Scale API v1.0 redirect",
+            "from": "^\\/api-ref-auto-scale.html$",
+            "to": "/docs/autoscale/v1/developer-guide/#api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Backup redirect",
+            "from": "^\\/api-ref-backup.html$",
+            "to": "/docs/cloud-backup/v1/developer-guide/#api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Big Data API v2 redirect",
+            "from": "^\\/api-ref-big-data-v2.html$",
+            "to": "docs/cloud-big-data/v2/developer-guide/#api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Block Storage redirect",
+            "from": "^\\/api-ref-blockstorage.html$",
+            "to": "/docs/cloud-block-storage/v1/developer-guide/#api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Databases redirect",
+            "from": "^\\/api-ref-databases.html$",
+            "to": "/docs/cloud-databases/v1/developer-guide/#api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud DNS redirect",
+            "from": "^\\/api-ref-dns.html$",
+            "to": "/docs/cloud-dns/v1/developer-guide/#api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Files redirect",
+            "from": "^\\/api-ref-files.html$",
+            "to": "/docs/cloud-files/v1/developer-guide/#api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Images redirect",
+            "from": "^\\/api-ref-images.html$",
+            "to": "/docs/cloud-images/v2/developer-guide/#api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Load Balancers redirect",
+            "from": "^\\/api-ref-load-balancers.html$",
+            "to": "/docs/cloud-load-balancers/v1/developer-guide/#api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Monitoring redirect",
+            "from": "^\\/api-ref-monitoring.html$",
+            "to": "/docs/cloud-monitoring/v1/developer-guide/#document-api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Networks redirect",
+            "from": "^\\/api-ref-networks.html$",
+            "to": "/docs/cloud-networks/v2/developer-guide/#document-api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Orchestration redirect",
+            "from": "^\\/api-ref-orchestration.html$",
+            "to": "/docs/cloud-orchestration/v1/developer-guide/#document-api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Cloud Queues redirect",
+            "from": "^\\/api-ref-queues.html$",
+            "to": "/docs/cloud-queues/v1/developer-guide/#document-api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Rackspace CDN redirect",
+            "from": "^\\/api-ref-raxCDN.html$",
+            "to": "/docs/cdn/v1/developer-guide/#document-api-reference",
+            "rewrite": false,
+            "status": 301
+        }
     ]
 }

--- a/config/rewrites.json
+++ b/config/rewrites.json
@@ -193,7 +193,7 @@
         {
             "description": "Cloud Big Data API v2 redirect",
             "from": "^\\/api-ref-big-data-v2(\\.html)?",
-            "to": "docs/cloud-big-data/v2/developer-guide/#api-reference",
+            "to": "/docs/cloud-big-data/v2/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
         },
@@ -220,7 +220,7 @@
         },
         {
             "description": "Cloud Files redirect",
-            "from": "^\\/api-ref-files.html$",
+            "from": "^\\/api-ref-files(\\.html)?",
             "to": "/docs/cloud-files/v1/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
@@ -287,8 +287,7 @@
             "to": "/docs/cloud-identity/v2/developer-guide/#document-api-reference",
             "rewrite": false,
             "status": 301
-        }
-        ,
+        },
         {
             "description": "Keep (Barbican) API redirect",
             "from": "^\\/api-ref-keep2(\\.html)?",

--- a/config/rewrites.json
+++ b/config/rewrites.json
@@ -169,6 +169,13 @@
             "status": 301
         },
         {
+            "description": "Cloud Servers extensions redirect",
+            "from": "^\\/api-ref-servers-ext.html$",
+            "to": "/docs/cloud-servers/v2/developer-guide/#api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
             "description": "Auto Scale API v1.0 redirect",
             "from": "^\\/api-ref-auto-scale.html$",
             "to": "/docs/autoscale/v1/developer-guide/#api-reference",
@@ -263,6 +270,28 @@
             "description": "Rackspace CDN redirect",
             "from": "^\\/api-ref-raxCDN.html$",
             "to": "/docs/cdn/v1/developer-guide/#document-api-reference",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Email and Apps API redirect",
+            "from": "^\\/api-ref-email-and-apps.html$",
+            "to": "/docs/",
+            "rewrite": false,
+            "status": 301
+        },
+        {
+            "description": "Identity API redirect",
+            "from": "^\\/api-ref-identity.html$",
+            "to": "/docs/cloud-identity/v2/developer-guide/#document-api-reference",
+            "rewrite": false,
+            "status": 301
+        }
+        ,
+        {
+            "description": "Keep (Barbican) API redirect",
+            "from": "^\\/api-ref-keep2.html$",
+            "to": "/docs/",
             "rewrite": false,
             "status": 301
         }

--- a/config/rewrites.json
+++ b/config/rewrites.json
@@ -155,7 +155,8 @@
         }
     ],
     "api.rackspace.com": [
-        {  "description": "Redirect root traffic to developer.rs.com/docs/",
+        {
+            "description": "Redirect root traffic to developer.rs.com/docs/",
             "from": "^\\/$",
             "to": "/docs/",
             "rewrite": false,
@@ -163,56 +164,56 @@
         },
         {
             "description": "Cloud Servers redirect",
-            "from": "^\\/api-ref.html$",
+            "from": "^\\/(api-ref(\\.html)?)?$",
             "to": "/docs/cloud-servers/v2/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Cloud Servers extensions redirect",
-            "from": "^\\/api-ref-servers-ext.html$",
+            "from": "^\\/api-ref-servers-ext(\\.html)?$",
             "to": "/docs/cloud-servers/v2/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Auto Scale API v1.0 redirect",
-            "from": "^\\/api-ref-auto-scale.html$",
+            "from": "^\\/api-ref-auto-scale(\\.html)?$",
             "to": "/docs/autoscale/v1/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Cloud Backup redirect",
-            "from": "^\\/api-ref-backup.html$",
+            "from": "^\\/api-ref-backup(\\.html)?$",
             "to": "/docs/cloud-backup/v1/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Cloud Big Data API v2 redirect",
-            "from": "^\\/api-ref-big-data-v2.html$",
+            "from": "^\\/api-ref-big-data-v2(\\.html)?",
             "to": "docs/cloud-big-data/v2/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Cloud Block Storage redirect",
-            "from": "^\\/api-ref-blockstorage.html$",
+            "from": "^\\/api-ref-blockstorage(\\.html)?",
             "to": "/docs/cloud-block-storage/v1/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Cloud Databases redirect",
-            "from": "^\\/api-ref-databases.html$",
+            "from": "^\\/api-ref-databases(\\.html)?",
             "to": "/docs/cloud-databases/v1/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Cloud DNS redirect",
-            "from": "^\\/api-ref-dns.html$",
+            "from": "^\\/api-ref-dns(\\.html)?",
             "to": "/docs/cloud-dns/v1/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
@@ -226,63 +227,63 @@
         },
         {
             "description": "Cloud Images redirect",
-            "from": "^\\/api-ref-images.html$",
+            "from": "^\\/api-ref-images(\\.html)?",
             "to": "/docs/cloud-images/v2/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Cloud Load Balancers redirect",
-            "from": "^\\/api-ref-load-balancers.html$",
+            "from": "^\\/api-ref-load-balancers(\\.html)?",
             "to": "/docs/cloud-load-balancers/v1/developer-guide/#api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Cloud Monitoring redirect",
-            "from": "^\\/api-ref-monitoring.html$",
+            "from": "^\\/api-ref-monitoring(\\.html)?",
             "to": "/docs/cloud-monitoring/v1/developer-guide/#document-api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Cloud Networks redirect",
-            "from": "^\\/api-ref-networks.html$",
+            "from": "^\\/api-ref-networks(\\.html)?",
             "to": "/docs/cloud-networks/v2/developer-guide/#document-api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Cloud Orchestration redirect",
-            "from": "^\\/api-ref-orchestration.html$",
+            "from": "^\\/api-ref-orchestration(\\.html)?",
             "to": "/docs/cloud-orchestration/v1/developer-guide/#document-api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Cloud Queues redirect",
-            "from": "^\\/api-ref-queues.html$",
+            "from": "^\\/api-ref-queues(\\.html)?",
             "to": "/docs/cloud-queues/v1/developer-guide/#document-api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Rackspace CDN redirect",
-            "from": "^\\/api-ref-raxCDN.html$",
+            "from": "^\\/api-ref-raxCDN(\\.html)?",
             "to": "/docs/cdn/v1/developer-guide/#document-api-reference",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Email and Apps API redirect",
-            "from": "^\\/api-ref-email-and-apps.html$",
+            "from": "^\\/api-ref-email-and-apps(\\.html)?",
             "to": "/docs/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Identity API redirect",
-            "from": "^\\/api-ref-identity.html$",
+            "from": "^\\/api-ref-identity(\\.html)?",
             "to": "/docs/cloud-identity/v2/developer-guide/#document-api-reference",
             "rewrite": false,
             "status": 301
@@ -290,7 +291,7 @@
         ,
         {
             "description": "Keep (Barbican) API redirect",
-            "from": "^\\/api-ref-keep2.html$",
+            "from": "^\\/api-ref-keep2(\\.html)?",
             "to": "/docs/",
             "rewrite": false,
             "status": 301


### PR DESCRIPTION
Don't merge until January 4th or so. Fixes Issue https://github.com/deconst/deconst-docs/issues/209

Should redirect from a service's html file to the API Reference. I don't have a way to test locally, though.
