### PR TITLE
Removed version number from the Identity github repository name

### DIFF
--- a/config/content.json
+++ b/config/content.json
@@ -23,7 +23,7 @@
             "/docs/cloud-servers/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-servers/",
             "/docs/cloud-files/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-files/",
             "/docs/metrics/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-metrics/",
-            "/docs/cloud-identity/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-identity-2.0/",
+            "/docs/cloud-identity/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-identity/",
             "/docs/cloud-monitoring/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-monitoring/",
             "/docs/dedicated-load-balancers/v2/dev-guide/": "https://github.com/rackerlabs/docs-dedicated-networking/",
             "/docs/glossary/": "https://github.com/rackerlabs/docs-common/"


### PR DESCRIPTION
@smashwilson 

I updated the deconst.json file in the Identity Sphinx project.  The Strider build seems to work fine with the name change.  Do I need to change the name of the Strider project to reflect the correct github repository name.

Are any other changes required?

Thanks,

Margaret
