### PR TITLE
Add npm entrypoints for the build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "[![Build Status](https://travis-ci.org/rackerlabs/nexus-control.svg?branch=master)](https://travis-ci.org/rackerlabs/nexus-control)",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "grunt build",
+    "deconst-control-build": "npm start"
   },
   "repository": {
     "type": "git",
@@ -18,6 +19,7 @@
     "cheerio": "^0.19.0",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.8.0",
+    "grunt-cli": "^0.1.13",
     "grunt-concurrent": "^2.0.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.1",


### PR DESCRIPTION
I'm going to be using this for the generic Strider control repository build. This will make sure that I don't break anything when I update the quay.io/deconst/preparer-asset container to run npm instead of grunt.
