### PR TITLE
restore redirect to /white-paper/

### DIFF
--- a/config/rewrites.d/support.rackspace.com.json
+++ b/config/rewrites.d/support.rackspace.com.json
@@ -15,6 +15,13 @@
           "toPort": "20096",
           "rewrite": false,
           "status": 302
+      },
+      {
+          "description": "white-paper index to all articles",
+          "from": "^\\/white-paper\\/$",
+          "to": "/white-paper/white-paper-all-articles/",
+          "rewrite": false,
+          "status": 301
       }
   ]
 }


### PR DESCRIPTION
Looks like this redirect was lost during the config file restructuring. Adding it back in its new home.
