### PR TITLE
use the same HaaS as all other properties

### DIFF
--- a/templates/support.rackspace.com/_layouts/raw.html
+++ b/templates/support.rackspace.com/_layouts/raw.html
@@ -12,7 +12,7 @@
         <link rel="canonical" href="{{ siteUrl }}">
         <link rel="stylesheet" href="{{ cssUrl }}">
 
-        <script src="https://c4d62906a15616653758-49dececd4e3f03377b7f33fac7abfae8.ssl.cf5.rackcdn.com/prod/raxheaderservice-howto.js"></script>
+        <script src="https://c4d62906a15616653758-49dececd4e3f03377b7f33fac7abfae8.ssl.cf5.rackcdn.com/prod/raxheaderservice.js"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
         <script type="text/javascript" src="{{ jsUrl }}"></script>
     {% endblock %}


### PR DESCRIPTION
We just released the new Header as a Service on all our other properties, so there's no need to maintain a special "howto" version.  This changes the HaaS we are using in How-To so it matches all the other properties.
