### PR TITLE
Redirect all knowledge-center articles to how-tos.

### DIFF
--- a/config/rewrites.d/support.rackspace.com.json
+++ b/config/rewrites.d/support.rackspace.com.json
@@ -38,11 +38,18 @@
           "status": 301
       },
       {
-        "description": "Redirect /knowledge_center/email-apps/ to /how-to#cloud-office",
-        "from": "^\\/knowledge_center\\/email-apps\\/?",
-        "to": "/how-to/#cloud-office",
-        "rewrite": false,
-        "status": 301
+          "description": "Redirect /knowledge_center/email-apps/ to /how-to#cloud-office",
+          "from": "^\\/knowledge_center\\/email-apps\\/?",
+          "to": "/how-to/#cloud-office",
+          "rewrite": false,
+          "status": 301
+      },
+      {
+          "description": "Redirect all /knowledge_center/article/ links to /how-to/.",
+          "from": "^\\/knowledge_center\\/article\\/(.*)$",
+          "to": "/how-to/$1",
+          "rewrite": false,
+          "status": 301
       }
   ]
 }


### PR DESCRIPTION
There's currently a catch-all redirect from `https://rackspace.com/knowledge_center/*` to `https://support.rackspace.com/knowledge_center/*`. This rule will redirect those incoming "`/article/*`" requests to `https://support.rackspace.com/how_to/*`.
