### PR TITLE
Map Cloud DNS v2 documentation

### DIFF
--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -10,6 +10,7 @@
           "/docs/cloud-load-balancers/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-load-balancers/v1/",
           "/docs/cloud-block-storage/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-block-storage/",
           "/docs/cloud-dns/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-dns/v1/",
+          "/docs/cloud-dns/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-dns/v2/",
           "/docs/cdn/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-cdn/",
           "/docs/cloud-databases/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-databases/v1/",
           "/docs/cloud-backup/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-backup/v1/",


### PR DESCRIPTION
When merged, this will map [the v2 documentation for Cloud DNS](https://github.com/rackerlabs/docs-cloud-dns/tree/master/api-docs/v2) to a the path [`/docs/cloud-dns/v2/developer-guide/`](https://developer.rackspace.com/docs/cloud-dns/v2/developer-guide/). At that point, it'll be accessible with your browser if you type out the URL, but it won't be linked from anywhere yet (er, other than this PR).

@catlook: Say the word when you're ready for this to :ship:.
