### PR TITLE
don't let curly braces in blogs/docs break all of Angular

### DIFF
--- a/templates/getcarina.com/docs-single.html
+++ b/templates/getcarina.com/docs-single.html
@@ -46,7 +46,7 @@
   <section class="docs-section article">
     <div class="section-container">
       <div class="section-grid">
-        <article>
+        <article data-ng-non-bindable>
           {{ deconst.content.envelope.body }}
           {% if deconst.request.path.match('^/blog') and deconst.content.envelope.meta.authorIsRacker == false %}
           <div class="guest-post-message">


### PR DESCRIPTION
Go templates like `{{.ID}}` were breaking _all_ of Angular on the page, which needless to say is a pretty bad thing. By telling Angular not to bind the div containing post content, we can allow posts to use angular-looking expressions without breaking the entire site.
