### PR TITLE
Map docs-cloud-backup v2.

### DIFF
--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -14,6 +14,7 @@
           "/docs/cdn/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-cdn/",
           "/docs/cloud-databases/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-databases/v1/",
           "/docs/cloud-backup/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-backup/v1/",
+          "/docs/cloud-backup/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-backup/v2/",
           "/docs/cloud-orchestration/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-orchestration/",
           "/docs/cloud-orchestration/v1/resources-reference/": "https://github.com/rackerlabs/heat-resource-ref/",
           "/docs/rackconnect/v3/developer-guide/": "https://github.com/rackerlabs/docs-cloud-rackconnect/",

--- a/config/routes.d/developer.rackspace.com.json
+++ b/config/routes.d/developer.rackspace.com.json
@@ -21,6 +21,7 @@
             "^/docs/cdn/v1/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-databases/v1/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-backup/v1/developer-guide": "docs-singlepage.html",
+            "^/docs/cloud-backup/v2/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-orchestration/v1/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-orchestration/v1/resources-reference": "user-guide.html",
             "^/docs/rackconnect/v3/developer-guide": "docs-singlepage.html",


### PR DESCRIPTION
This will make the v2 docs available at [/docs/cloud-backup/v2/developer-guide](https://developer.rackspace.com/docs/cloud-backup/v2/developer-guide).

Fixes #331.
