### PR TITLE
Map docs-cloud-load-balancers v2.

### DIFF
--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -8,6 +8,7 @@
           "/docs/rack-cli/": "https://github.com/rackspace/rack/",
           "/docs/cloud-images/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-images/",
           "/docs/cloud-load-balancers/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-load-balancers/v1/",
+          "/docs/cloud-load-balancers/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-load-balancers/v2/",
           "/docs/cloud-block-storage/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-block-storage/",
           "/docs/cloud-dns/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-dns/v1/",
           "/docs/cloud-dns/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-dns/v2/",

--- a/config/routes.d/developer.rackspace.com.json
+++ b/config/routes.d/developer.rackspace.com.json
@@ -16,6 +16,7 @@
             "^/docs/user-guides/orchestration/": "user-guide.html",
             "^/docs/cloud-images/v2/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-load-balancers/v1/developer-guide": "docs-singlepage.html",
+            "^/docs/cloud-load-balancers/v2/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-block-storage/v1/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-dns/v1/developer-guide": "docs-singlepage.html",
             "^/docs/cdn/v1/developer-guide": "docs-singlepage.html",


### PR DESCRIPTION
This will make the v2 docs available at [/docs/cloud-load-balancers/v2/developer-guide](https://developer.rackspace.com/docs/cloud-load-balancers/v2/developer-guide).

Fixes #330.
