### PR TITLE
add content ID bases for both versions of RPC docs

### DIFF
--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -31,7 +31,8 @@
           "/docs/cloud-keep/v1/developer-guide/": "https://github.com/rackerlabs/docs-barbican/",
           "/docs/dedicated-load-balancers/v2/dev-guide/": "https://github.com/rackerlabs/docs-dedicated-networking/",
           "/docs/glossary/": "https://github.com/rackerlabs/docs-common/",
-          "/docs/private-cloud/rpc/": "https://github.com/rackerlabs/docs-rpc/",
+          "/docs/private-cloud/rpc/v11": "https://github.com/rackerlabs/docs-rpc/v11/",
+          "/docs/private-cloud/rpc/v10": "https://github.com/rackerlabs/docs-rpc/v10/",
           "/docs/private-cloud/dedicated-vcloud/": "https://github.com/rackerlabs/docs-dedicated-vcloud/",
           "/docs/private-cloud/red-hat/": "https://github.com/rackerlabs/docs-redhat-osp/"
       },

--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -76,6 +76,10 @@
             "toPort": "20096",
             "rewrite": false,
             "status": 302
+        },
+        {
+          "from": "^/docs/private-cloud/rpc/?$",
+          "to": "/docs/private-cloud/rpc/v11"
         }
     ]
 }


### PR DESCRIPTION
both versions v10 and v11 of their docs need to be published.
