### PR TITLE
docs-cloud-identity-2.0 was renamed

### DIFF
--- a/content-repositories.json
+++ b/content-repositories.json
@@ -2,7 +2,7 @@
   { "kind": "github", "project": "rackerlabs/otter" },
   { "kind": "github", "project": "rackerlabs/standard-usage-schemas" },
   { "kind": "github", "project": "rackerlabs/docs-rpc" },
-  { "kind": "github", "project": "rackerlabs/docs-cloud-identity-2.0" },
+  { "kind": "github", "project": "rackerlabs/docs-cloud-identity" },
   { "kind": "github", "project": "rackerlabs/docs-dedicated-vcloud" },
   { "kind": "github", "project": "rackerlabs/docs-redhat-osp" },
   { "kind": "github", "project": "rackerlabs/heat-resource-ref" },


### PR DESCRIPTION
It looks like the control builder won't follow repository renames. Honestly, that's probably a feature.
