### PR TITLE
Redirect out-dated tutorials to the overlay network tutorial

### DIFF
--- a/config/rewrites.d/getcarina.com.json
+++ b/config/rewrites.d/getcarina.com.json
@@ -117,6 +117,24 @@
           "to": "/docs/reference/glossary/",
           "rewrite": false,
           "status": 301
+        },
+        {
+          "from": "\\/docs\\/concepts\\/docker-networking-basics\\/?",
+          "to": "/docs/tutorials/overlay-networks/",
+          "rewrite": false,
+          "status": 301
+        },
+        {
+          "from": "\\/docs\\/tutorials\\/connect-docker-containers-with-links\\/?",
+          "to": "/docs/tutorials/overlay-networks/",
+          "rewrite": false,
+          "status": 301
+        },
+        {
+          "from": "\\/docs\\/tutorials\\/connect-docker-containers-ambassador-pattern\\/?",
+          "to": "/docs/tutorials/overlay-networks/",
+          "rewrite": false,
+          "status": 301
         }
     ]
 }


### PR DESCRIPTION
Can't merge this until the overlay network tutorial https://github.com/getcarina/getcarina.com/pull/726 is published.
