### PR TITLE
center images in non-floated figure tags

### DIFF
--- a/assets/getcarina.com/src/css/less/pages/docs-single.less
+++ b/assets/getcarina.com/src/css/less/pages/docs-single.less
@@ -112,7 +112,13 @@ body.docs-single {
 
     figure {
       img {
-        margin: 0 0 0.25em 0;
+        margin: 0 auto 0.25em auto;
+      }
+      
+      &.right, &.left {
+        img {
+          margin: 0 0 0.25em 0;
+        }
       }
 
       figcaption {


### PR DESCRIPTION
Fixes https://github.com/getcarina/getcarina.com/issues/735
