### PR TITLE
Add an explicit string for Cloud Intel to check

### DIFF
--- a/templates/developer.rackspace.com/index.html
+++ b/templates/developer.rackspace.com/index.html
@@ -23,5 +23,10 @@
 {% set tagline = deconst.content.envelope.meta.tagline %}
 
 {% block bodyContent %}
+    {#
+      Cloud Intelligence expects this HTML comment to appear on the home page.
+      Don't remove it unless you want to have a bad time.
+    #}
+    <!-- SITE-MONITORING-KEY: 03f04f0d8ab6e9e0  -->
     {{ deconst.content.envelope.body }}
 {% endblock %}


### PR DESCRIPTION
The HTML comment as suggested in https://github.com/rackerlabs/devex-ops/issues/26 appears within the index template, which means our cloud intelligence warning would also trigger if our template-routing rules are extremely broken. It also includes a little hex string, mostly just to look important. ¯_(ツ)_/¯
