### PR TITLE
Redirect KC Frequently_Asked_Questions

### DIFF
--- a/config/rewrites.d/support.rackspace.com.json
+++ b/config/rewrites.d/support.rackspace.com.json
@@ -43,6 +43,13 @@
         "to": "/how-to/#cloud-office",
         "rewrite": false,
         "status": 301
+      },
+      {
+        "description": "Redirect /knowledge_center/Frequently_Asked_Questions/ to /how-to/cloud-servers-faq/",
+        "from": "^\\/knowledge_center\\/Frequently_Asked_Questions\\/?",
+        "to": "/how-to/cloud-servers-faq/",
+        "rewrite": false,
+        "status": 301
       }
   ]
 }


### PR DESCRIPTION
fixes a broken link from the old docs website to the old knowledge center

requested by @catlook 
