### PR TITLE
Remove docs-common repo

### DIFF
--- a/content-repositories.json
+++ b/content-repositories.json
@@ -11,7 +11,6 @@
   { "kind": "github", "project": "rackerlabs/docs-cloud-backup" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-block-storage" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-cdn" },
-  { "kind": "github", "project": "rackerlabs/docs-common" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-databases" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-dns" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-big-data"},


### PR DESCRIPTION
After the glossary was moved to the docs-rackspace repository, the docs-common repo no longer contains any Sphinx projects.  Removing the repo from the Strider build configuration.
