### PR TITLE
Redirecting /signup to public cloud cart

### DIFF
--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -33,6 +33,13 @@
             "status": 301
         },
         {
+            "from": "^\\/signup",
+            "to": "/cloud",
+            "toProtocol": "https",
+            "toHostname": "cart.rackspace.com",
+            "status": "301"
+        },
+        {
             "from": "^\\/sdks\\/?$",
             "to": "/docs/#sdks",
             "rewrite": false,


### PR DESCRIPTION
This is part of a two phase change:
1. Redirect the `/signup` path to the public cart in `nexus-control`
2. Remove the pages at `/signup` in `docs-developer-blog`

Let me know if I've done the syntax wrong.
