### PR TITLE
Fixing a broken redirect for /signup

### DIFF
--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -37,6 +37,7 @@
             "to": "/cloud",
             "toProtocol": "https",
             "toHostname": "cart.rackspace.com",
+            "rewrite": false,
             "status": "301"
         },
         {


### PR DESCRIPTION
Looks like we were missing a `"rewrite": false` property on the rewrite.
