### PR TITLE
Add the how-to redirect for monitoring

### DIFF
--- a/config/rewrites.d/support.rackspace.com.json
+++ b/config/rewrites.d/support.rackspace.com.json
@@ -50,6 +50,13 @@
         "to": "/how-to/cloud-servers-faq/",
         "rewrite": false,
         "status": 301
-      }
+      },
+      {
+        "description": "Redirect /how-to/cloud-monitoring URLs to /how-to/rackspace-monitoring",
+         "from": "^\\/how-to\\/cloud-monitoring\\/?(.*)$",
+         "to": "/how-to/rackspace-monitoring/$1",
+         "rewrite": false,
+         "status": 301
+      },
   ]
 }

--- a/config/rewrites.d/support.rackspace.com.json
+++ b/config/rewrites.d/support.rackspace.com.json
@@ -57,6 +57,6 @@
          "to": "/how-to/rackspace-monitoring/$1",
          "rewrite": false,
          "status": 301
-      },
+      }
   ]
 }


### PR DESCRIPTION
@smashwilson or @kbartholomew   Not sure if I got the syntax correct, but on the how-to site, URLs that go to the old monitoring product name (https://support.rackspace.com/how-to/cloud-monitoring-faq/)  still return a 404.   I think it's because we didn't add the rewrite rule to the support.rackspace.com site, although it was added to the developer.rackspace.com rewrite file.
