### PR TITLE
Create a Strider build for Rack docs

### DIFF
--- a/content-repositories.json
+++ b/content-repositories.json
@@ -24,11 +24,12 @@
   { "kind": "github", "project": "rackerlabs/docs-cloud-orchestration" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-queues" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-rackconnect" },
-  { "kind": "github", "project": "rackerlabs/docs-dedicated-networking" }, 
+  { "kind": "github", "project": "rackerlabs/docs-dedicated-networking" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-servers" },
   { "kind": "github", "project": "rackerlabs/docs-rackspace" },
   { "kind": "github", "project": "rackerlabs/heat-resource-ref" },
   { "kind": "github", "project": "rackerlabs/otter" },
   { "kind": "github", "project": "rackerlabs/rs-heat-docs" },
-  { "kind": "github", "project": "rackerlabs/standard-usage-schemas" }
+  { "kind": "github", "project": "rackerlabs/standard-usage-schemas" },
+  { "kind": "github", "project": "rackspace/rack" }
 ]


### PR DESCRIPTION
The Rack docs have been built manually before this, I believe. Once merged, this will configure a [Strider](https://build.developer.rackspace.com/) build that will automatically deploy the Rack docs to Nexus on each commit pushed to master.

/cc @jrperritt 
