### PR TITLE
Redesign docs nav

### DIFF
--- a/assets/src/css/less/components/docs-section-nav.less
+++ b/assets/src/css/less/components/docs-section-nav.less
@@ -67,17 +67,26 @@
         padding: 0;
         width: 100%;
 
-        & > li {
-            & > a {
+        & > li.toctree-l1:first-of-type a {
+            .titillium('bold');
+            text-transform: uppercase;
+        }
+
+        li {
+            a {
                 .titillium();
                 background: transparent;
                 border-radius: 1px;
                 color: tint(@text-color, 20%);
-                display: inline-block;
+                display: block;
                 font-size: 16px;
-                padding: 0.4em;
+                padding: 0.4em 0.5em;
                 text-decoration: none;
-                .transition(~"background 0.1s ease-in-out, color 0.1s ease-in-out");
+
+                &.active {
+                    background: fadeout(@link-color, 80%);
+                    box-shadow: inset 3px 0px 0px 0px @link-color;
+                }
 
                 &:hover {
                     color: @link-color;
@@ -88,61 +97,14 @@
                 margin-top: 0px;
             }
 
-            &.active > a {
-                background: @link-color;
-                color: white;
-                letter-spacing: -0.04em;
-            }
-
             ul {
-                border-left: dotted 1px shade(white, 30%);
                 list-style-type: none;
-                margin: 20px 0 20px 7px;
-                padding: 0 0 0 10px;
+                margin: 0;
+                padding: 0;
 
-                li {
-                    line-height: 1;
-
-                    a {
-                        color: @text-color;
-                        line-height: 1;
-                        text-decoration: none;
-
-                        &:hover {
-                            color: @link-color;
-                        }
-                    }
-
-                    & + li {
-                        margin-top: 10px;
-                    }
+                li a {
+                    padding-left: 20px;
                 }
-            }
-        }
-
-        li {
-            &:before {
-                background: @rax-yellow;
-                border-radius: 50%;
-                content: '';
-                display: block;
-                height: 13px;
-                left: -17px;
-                position: absolute;
-                top: 1px;
-                .transform(scale(0));
-                .transition(transform 0.1s ease-in);
-                width: 13px;
-            }
-
-            &.active:before {
-                .transform(scale(1));
-                .transition(transform 0.1s 0.1s ease-out);
-            }
-
-            &.active > a {
-                .open-sans('bold');
-                letter-spacing: -0.04em;
             }
         }
     }
@@ -157,10 +119,10 @@
     }
 
     @media (min-width: 1025px) {
-        padding: 15px 20px 0 35px;
+        padding: 15px 20px 0 20px;
 
         &.sticky {
-            @sticky-width: (1 / 5 * 100);
+            @sticky-width: (1/4 * 100);
             width: ~"calc(@{sticky-width}%)";
         }
     }

--- a/assets/src/css/less/components/docs-section-nav.less
+++ b/assets/src/css/less/components/docs-section-nav.less
@@ -65,6 +65,7 @@
         margin: 0;
         overflow: hidden;
         padding: 0;
+        padding-left: 20px;
         width: 100%;
 
         & > li.toctree-l1:first-of-type a {
@@ -73,11 +74,11 @@
         }
 
         li {
+            margin: 0;
+
             a {
                 .titillium();
-                background: transparent;
-                border-radius: 1px;
-                color: tint(@text-color, 20%);
+                color: @text-color;
                 display: block;
                 font-size: 16px;
                 padding: 0.4em 0.5em;
@@ -101,11 +102,38 @@
                 list-style-type: none;
                 margin: 0;
                 padding: 0;
+                padding-left: 20px;
 
                 li a {
                     padding-left: 20px;
                 }
             }
+        }
+    }
+
+    .collapse-target {
+        cursor: pointer;
+        display: inline-block;
+        height: 12px;
+        left: -12px;
+        position: absolute;
+        text-align: center;
+        top: 12px;
+        width: 12px;
+    }
+
+    li > ul {
+        max-height: 0px;
+        overflow-y: hidden;
+    }
+
+    li.open {
+        & > .collapse-target {
+            transform: rotate(90deg);
+        }
+
+        & > ul {
+            max-height: initial;
         }
     }
 

--- a/assets/src/css/less/layouts/docs-home.less
+++ b/assets/src/css/less/layouts/docs-home.less
@@ -74,6 +74,10 @@ body.docs-home {
             margin-bottom: 20px;
         }
 
+        & > ul {
+            padding-left: 0;
+        }
+
         @media (min-width: 769px) {
             &.sticky {
                 @sticky-width: (1 / 5 * 100);

--- a/assets/src/css/less/layouts/sidebar-left.less
+++ b/assets/src/css/less/layouts/sidebar-left.less
@@ -23,17 +23,17 @@
         @media (min-width: 769px) {
             .left {
                 .grid-unit(1/5);
-                background: shade(white, 8%);
+                background: shade(white, 2%);
                 height: 100%;
             }
         }
 
         @media (min-width: 1025px) {
             .left {
-                .grid-unit(1/5);
+                .grid-unit(1/4);
             }
             .center {
-                .grid-unit(4/5);
+                .grid-unit(3/4);
             }
         }
     }
@@ -43,6 +43,10 @@
 
         @media (min-width: 769px) {
             .grid-unit(1/5);
+        }
+
+        @media (min-width: 1025px) {
+            .grid-unit(1/4);
         }
     }
 
@@ -56,8 +60,12 @@
             max-width: 960px;
         }
 
+        @media (min-width: 1025px) {
+            .grid-unit(3/4);
+        }
+
         @media (min-width: 1302px) {
-            .grid-unit(4/5, 0px);
+            .grid-unit(3/4, 0px);
             padding: 0 0;
             margin-left: calc(40% - 480px);
         }

--- a/assets/src/css/less/layouts/sidebar-left.less
+++ b/assets/src/css/less/layouts/sidebar-left.less
@@ -24,6 +24,7 @@
             .left {
                 .grid-unit(1/5);
                 background: shade(white, 2%);
+                border-right: solid 1px shade(white, 8%);
                 height: 100%;
             }
         }
@@ -67,7 +68,7 @@
         @media (min-width: 1302px) {
             .grid-unit(3/4, 0px);
             padding: 0 0;
-            margin-left: calc(40% - 480px);
+            margin-left: calc(37.5% - 480px);
         }
     }
 

--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -9,6 +9,7 @@ angular.module(moduleName, [
     require('angular-sanitize'),
     require('./components/code-sample'),
     require('./components/code-sample-parent'),
+    require('./components/collapsible-nav'),
     require('./components/collapsible-section'),
     require('./components/database-jump'),
     require('./components/dropdown-toggle'),

--- a/assets/src/js/components/collapsible-nav.js
+++ b/assets/src/js/components/collapsible-nav.js
@@ -1,0 +1,46 @@
+var _ = require('lodash');
+var angular = require('angular');
+
+var moduleName = 'drc.components.collapsible-nav';
+module.exports = moduleName;
+
+angular.module(moduleName, [])
+.directive('drcCollapsibleNav', [function () {
+    return {
+        controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {
+
+        }],
+        link: function ($scope, $element, $attrs) {
+            var element = $element[0];
+            var createCollapseTarget = function () {
+                var target = document.createElement('div');
+                target.className = 'fa fa-caret-right collapse-target';
+
+                target.addEventListener('click', function (e) {
+                    var targetParent = e.target.parentNode;
+
+                    if (targetParent.classList.contains('open')) {
+                        targetParent.classList.remove('open');
+                    } else {
+                        targetParent.classList.add('open');
+                    }
+                });
+
+                return target;
+            }
+
+            // Loop through all the <li> tags we can find
+            var listItems = element.querySelectorAll('li');
+            _.forEach(listItems, function (element, index, array) {
+                if (element.querySelector('ul') === null) {
+                    return;
+                }
+
+                // If the <li> has a child <ul>, it is a parent and needs to
+                // handle collapsing/de-collapsing
+                element.insertBefore(createCollapseTarget(), element.children[0]);
+
+            });
+        }
+    };
+}]);

--- a/assets/src/js/components/scroll-indicator.js
+++ b/assets/src/js/components/scroll-indicator.js
@@ -90,10 +90,7 @@ module.exports = angular.module('drc.components.scroll-indicator', [])
               var indicatorLink = $element.find('[href="#' + data +'"]');
                 window.requestAnimationFrame(function () {
                   $element.find('a[href]').removeClass('active');
-                  $element.find('li').removeClass('active');
-
                   indicatorLink.addClass('active');
-                  indicatorLink.parents('li').addClass('active');
                 });
             });
         }],

--- a/templates/developer.rackspace.com/docs-singlepage.html
+++ b/templates/developer.rackspace.com/docs-singlepage.html
@@ -27,7 +27,7 @@
 {% set tagline = 'Let’s Build Something Powerful Together!' %}
 
 {% block sidebar %}
-    <div class="sidebar-container" data-drc-sticky data-offset-top="356" data-drc-flex-height data-flex-bottom="443" data-drc-scroll-indicator data-use-attribute="id">
+    <div class="sidebar-container" data-drc-sticky data-offset-top="322" data-drc-flex-height data-flex-bottom="443" data-drc-scroll-indicator data-use-attribute="id" data-drc-collapsible-nav>
         {% if deconst.content.envelope.meta.github_issues_url or deconst.content.envelope.meta.github_edit_url %}
           {% if deconst.content.envelope.meta.preferGithubIssues %}
             {% set githubLinkUrl = deconst.content.envelope.meta.github_issues_url %}
@@ -41,7 +41,7 @@
             <span class="link-text">{{ githubLinkText }}</span>
           </a>
         {% endif %}
-        {{ deconst.content.envelope.toc|limitListDepth(2) }}
+        {{ deconst.content.envelope.toc }}
     </div>
 {% endblock %}
 

--- a/templates/developer.rackspace.com/docs-singlepage.html
+++ b/templates/developer.rackspace.com/docs-singlepage.html
@@ -27,7 +27,7 @@
 {% set tagline = 'Let’s Build Something Powerful Together!' %}
 
 {% block sidebar %}
-    <div class="sidebar-container" data-drc-sticky data-offset-top="322" data-drc-flex-height data-flex-bottom="443" data-drc-scroll-indicator data-use-attribute="id" data-drc-collapsible-nav>
+    <div class="sidebar-container" data-drc-sticky data-offset-top="321" data-drc-flex-height data-flex-bottom="443" data-drc-scroll-indicator data-use-attribute="id" data-drc-collapsible-nav>
         {% if deconst.content.envelope.meta.github_issues_url or deconst.content.envelope.meta.github_edit_url %}
           {% if deconst.content.envelope.meta.preferGithubIssues %}
             {% set githubLinkUrl = deconst.content.envelope.meta.github_issues_url %}

--- a/templates/developer.rackspace.com/rack-cli.html
+++ b/templates/developer.rackspace.com/rack-cli.html
@@ -28,7 +28,7 @@
 
 {% block sidebar %}
     <div data-drc-global-sidebar>
-        <div class="sidebar-container" data-drc-sticky data-offset-top="321" data-drc-flex-height data-flex-bottom="412">
+        <div class="sidebar-container" data-drc-sticky data-offset-top="321" data-drc-flex-height data-flex-bottom="412" data-drc-collapsible-nav>
             {{ deconst.content.globals.toc|unwrap('div.toctree-wrapper')|removeAnchors }}
         </div>
     </div>

--- a/templates/developer.rackspace.com/user-guide.html
+++ b/templates/developer.rackspace.com/user-guide.html
@@ -28,7 +28,7 @@
 
 {% block sidebar %}
   <div data-drc-global-sidebar>
-    <div class="sidebar-container" data-drc-sticky data-offset-top="321" data-drc-flex-height data-flex-bottom="443">
+    <div class="sidebar-container" data-drc-sticky data-offset-top="321" data-drc-flex-height data-flex-bottom="443" data-drc-collapsible-nav>
       {% if deconst.content.envelope.meta.github_issues_url or deconst.content.envelope.meta.github_edit_url %}
         {% if deconst.content.envelope.meta.preferGithubIssues %}
           {% set githubLinkUrl = deconst.content.envelope.meta.github_issues_url %}


### PR DESCRIPTION
Fixes https://github.com/rackerlabs/docs-workstream/issues/46.

Allows more depth in toctrees and adds collapsible triggers to any navigation items with children. Each collapsible section currently begins collapsed. In the future, we can add the ability to open/close sections as the user scrolls, but with the massive size of our single-page documents, that's not really a tenable feature.
