### PR TITLE
Remove trailing comma

### DIFF
--- a/config/content.d/staging.horse.json
+++ b/config/content.d/staging.horse.json
@@ -1,7 +1,7 @@
 {
   "staging.horse": {
     "content": {
-      "/docs/private-cloud/rpc/master/": "https://github.com/rackerlabs/docs-rpc/master/",
+      "/docs/private-cloud/rpc/master/": "https://github.com/rackerlabs/docs-rpc/master/"
     }
   }
 }


### PR DESCRIPTION
Preview links for docs-rpc's master branch were 404ing because the `staging.horse.json` file couldn't be parsed.

Yeah, the error reporting around these problem kind of stinks.
