### PR TITLE
Reference tables of contents as addenda.

### DIFF
--- a/templates/developer.rackspace.com/rack-cli.html
+++ b/templates/developer.rackspace.com/rack-cli.html
@@ -42,7 +42,7 @@
                 <span class="link-text">{{ githubLinkText }}</span>
               </a>
             {% endif %}
-            {{ deconst.content.globals.toc|unwrap('div.toctree-wrapper')|removeAnchors }}
+            {{ deconst.addenda.repository_toc.envelope.body|unwrap('div.toctree-wrapper')|removeAnchors }}
         </div>
     </div>
 {% endblock %}

--- a/templates/developer.rackspace.com/user-guide.html
+++ b/templates/developer.rackspace.com/user-guide.html
@@ -42,7 +42,7 @@
           <span class="link-text">{{ githubLinkText }}</span>
         </a>
       {% endif %}
-      {{ deconst.content.globals.toc|unwrap('div')|limitListDepth(3) }}
+      {{ deconst.addenda.repository_toc.envelope.body|unwrap('div')|limitListDepth(3) }}
     </div>
   </div>
 {% endblock %}

--- a/templates/staging.horse/rack-cli.html
+++ b/templates/staging.horse/rack-cli.html
@@ -29,7 +29,7 @@
 {% block sidebar %}
     <div data-drc-global-sidebar>
         <div class="sidebar-container" data-drc-sticky data-offset-top="321" data-drc-flex-height data-flex-bottom="412">
-            {{ deconst.content.globals.toc|unwrap('div.toctree-wrapper')|removeAnchors }}
+            {{ deconst.addenda.repository_toc.envelope.body|unwrap('div.toctree-wrapper')|removeAnchors }}
         </div>
     </div>
 {% endblock %}

--- a/templates/staging.horse/user-guide.html
+++ b/templates/staging.horse/user-guide.html
@@ -42,7 +42,7 @@
           <span class="link-text">{{ githubLinkText }}</span>
         </a>
       {% endif %}
-      {{ deconst.content.globals.toc|unwrap('div')|limitListDepth(3) }}
+      {{ deconst.addenda.repository_toc.envelope.body|unwrap('div')|limitListDepth(3) }}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Now that deconst/presenter#120 is shipping, we can reference tables of contents as "document addenda" rather than `deconst.content.globals.toc`.
