### PR TITLE
Use the multi-page template for cloud images and auto-open the ToC

### DIFF
--- a/assets/src/js/components/collapsible-nav.js
+++ b/assets/src/js/components/collapsible-nav.js
@@ -1,5 +1,6 @@
 var _ = require('lodash');
 var angular = require('angular');
+var URL = require('url-parse');
 
 var moduleName = 'drc.components.collapsible-nav';
 module.exports = moduleName;
@@ -12,6 +13,8 @@ angular.module(moduleName, [])
         }],
         link: function ($scope, $element, $attrs) {
             var element = $element[0];
+
+            // Create the caret icon used to indicate collapsing nav
             var createCollapseTarget = function () {
                 var target = document.createElement('div');
                 target.className = 'fa fa-caret-right collapse-target';
@@ -29,17 +32,85 @@ angular.module(moduleName, [])
                 return target;
             }
 
+            // Opens all parent lists, stopping at the directive element. Adds
+            // an "open" class to all <li> elements it finds
+            var openParentLists = function (child) {
+              // Stop recursing at the element on which this directive is defined
+              if (child.parentNode == element) {
+                return;
+              }
+
+              // Only add the open class to parent <li> tags
+              if (child.parentNode.tagName.toLowerCase() !== 'li') {
+                return openParentLists(child.parentNode);
+              }
+
+              // Add the open class to the parent li and recurse upwards
+              child.parentNode.classList.add('open');
+              return openParentLists(child.parentNode);
+            };
+
+            var resetActiveLinks = function () {
+              var links = element.querySelectorAll('a.active');
+              var lists = element.querySelectorAll('li.open');
+
+              // de-activate all links
+              _.forEach(links, function (link) {
+                link.classList.remove('active');
+              });
+
+              // close all open lists
+              _.forEach(lists, function (list) {
+                list.classList.remove('open');
+              });
+            };
+
+            // Reset the list and open the currently active link
+            var markLinkActive = function (link) {
+              resetActiveLinks();
+              link.classList.add('active');
+              openParentLists(link);
+
+              // Wait a bit for things to render, then try to scroll the active
+              // link into view
+              setTimeout(function () {
+                var elementFromTop = element.getBoundingClientRect().top;
+                var linkFromTop = link.getBoundingClientRect().top;
+
+                element.scrollTop = linkFromTop - elementFromTop;
+              }, 300);
+            };
+
             // Loop through all the <li> tags we can find
             var listItems = element.querySelectorAll('li');
-            _.forEach(listItems, function (element, index, array) {
-                if (element.querySelector('ul') === null) {
+            _.forEach(listItems, function (item, index, array) {
+                if (item.querySelector('ul') === null) {
                     return;
                 }
 
                 // If the <li> has a child <ul>, it is a parent and needs to
                 // handle collapsing/de-collapsing
-                element.insertBefore(createCollapseTarget(), element.children[0]);
+                item.insertBefore(createCollapseTarget(), item.children[0]);
+            });
 
+            // Loop through all the <a> tags we can find
+            var currentURL = new URL(window.location.href);
+            var links = element.querySelectorAll('a[href]');
+
+            _.forEach(links, function (link, index, array) {
+              var linkURL = new URL(link.href);
+              // only match URLs with the same pathname as the current location
+              if (currentURL.pathname !== linkURL.pathname) {
+                return;
+              }
+
+              if (currentURL.hash && currentURL.hash === linkURL.hash) {
+                // Pathname and hash both match, mark this as active
+                markLinkActive(link);
+              } else if (currentURL.hash === '' && linkURL.hash === '') {
+                // Hashes are both empty, mark this as active
+                markLinkActive(link);
+              }
             });
         }
     };

--- a/config/routes.d/developer.rackspace.com.json
+++ b/config/routes.d/developer.rackspace.com.json
@@ -14,7 +14,7 @@
             "^/docs/.+?": "docs-page.html",
             "^/docs/user-guides/infrastructure/": "user-guide.html",
             "^/docs/user-guides/orchestration/": "user-guide.html",
-            "^/docs/cloud-images/v2/developer-guide": "docs-singlepage.html",
+            "^/docs/cloud-images/v2/developer-guide": "user-guide.html",
             "^/docs/cloud-load-balancers/v1/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-load-balancers/v2/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-block-storage/v1/developer-guide": "docs-singlepage.html",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "envify": "^3.4.0",
     "event-emitter": "^0.3.4",
     "grunt": "^0.4.5",
-    "markalytics": "^0.1.3"
+    "markalytics": "^0.1.3",
+    "url-parse": "^1.1.1"
   }
 }

--- a/templates/developer.rackspace.com/user-guide.html
+++ b/templates/developer.rackspace.com/user-guide.html
@@ -42,7 +42,7 @@
           <span class="link-text">{{ githubLinkText }}</span>
         </a>
       {% endif %}
-      {{ deconst.addenda.repository_toc.envelope.body|unwrap('div')|limitListDepth(3) }}
+      {{ deconst.addenda.repository_toc.envelope.body }}
     </div>
   </div>
 {% endblock %}

--- a/templates/staging.horse/user-guide.html
+++ b/templates/staging.horse/user-guide.html
@@ -42,7 +42,7 @@
           <span class="link-text">{{ githubLinkText }}</span>
         </a>
       {% endif %}
-      {{ deconst.addenda.repository_toc.envelope.body|unwrap('div')|limitListDepth(3) }}
+      {{ deconst.addenda.repository_toc.envelope.body }}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Fixes #452 

This is not without its bugs, but it accomplishes the preliminary goal of using the multi-page template for the Cloud Images guide and adds the necessary code to auto-open the table of contents on page load.

See also https://github.com/rackerlabs/docs-cloud-images/pull/79

/cc @kenperkins @meker12 @kmsholcomb @lauracly 
