### PR TITLE
Use a builder-agnostic TOC reference in user-guide.html

### DIFF
--- a/templates/developer.rackspace.com/user-guide.html
+++ b/templates/developer.rackspace.com/user-guide.html
@@ -42,7 +42,11 @@
           <span class="link-text">{{ githubLinkText }}</span>
         </a>
       {% endif %}
-      {{ deconst.addenda.repository_toc.envelope.body }}
+      {% if deconst.addenda.repository_toc %}
+        {{ deconst.addenda.repository_toc.envelope.body }}
+      {% else %}
+        {{ deconst.content.envelope.toc }}
+      {% endif %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Content repositories rendered with the `user-guide.html` template will fall back to the local TOC if no repository-wide TOC is available. This prevents the TOC from disappearing when the routed template is changed before a content repository's builder is changed to match, as happened in rackerlabs/docs-cloud-load-balancers#134.

@meker12 : This should make it easier to transition content repositories from the `deconst-single` builder to `deconst-serial` without losing the TOC in the middle. To gracefully change a repository:
1. Submit and merge a pull request to nexus-control updating `config/routes.d/<site>.json` to change the template for the content repository from `docs-singlepage.html` to `user-guide.html`.
2. Submit and merge a pull request against the content repository changing the builder specified in `conf.py` from `deconst-single` to `deconst-serial`.
