### PR TITLE
add redirect from cdn limits to cdn faq

### DIFF
--- a/config/rewrites.d/support.rackspace.com.json
+++ b/config/rewrites.d/support.rackspace.com.json
@@ -79,7 +79,7 @@
         "rewrite": false,
         "status": 301
       },
-      { 
+      {
         "description": "Redirect support.rackspace.com/white-paper/systems-management-simplified-in-the-cloud/ URL to how-to/systems-management-simplified-in-the-cloud/ ",
         "from": "^\\/white-paper\\/systems-management-simplified-in-the-cloud(.*)$",
         "to": "/how-to/systems-management-simplified-in-the-cloud/",
@@ -111,6 +111,13 @@
         "description": "Redirect /how-to/rackspace-cloud-backup-overview/ URL to /how-to/best-practices-for-cloud-backup/",
         "from": "^\\/how-to\\/rackspace-cloud-backup-overview(.*)$",
         "to": "/how-to/best-practices-for-cloud-backup/",
+        "rewrite": false,
+        "status": 301
+      },
+      {
+        "description": "Redirect /how-to/limits-for-rackspace-cdn/ URL to /how-to/rackspace-cdn-faq/",
+        "from": "^\\/how-to\\/limits-for-rackspace-cdn(.*)$",
+        "to": "/how-to/rackspace-cdn-faq/",
         "rewrite": false,
         "status": 301
       }


### PR DESCRIPTION
Deleting Limits for Rackspace CDN article and moving info to Rackspace CDN FAQ. Adding redirect so as not to break anything for anyone.
