### PR TITLE
Fix load balancer redirect

### DIFF
--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -60,7 +60,7 @@
         },
         {
             "description": "Redirect load balancers developer-guide URL",
-            "from": "^\\/docs\\/docs-cloud-load-balancers\\/v1\\/developer-guide\\/(.*?)",
+            "from": "^\\/docs\\/cloud-load-balancers\\/v1\\/developer-guide\\/(.*?)",
             "to": "/docs/docs-cloud-load-balancers/v1/$1",
             "rewrite": false,
             "status": 301


### PR DESCRIPTION
Remove "docs" from the product name in "from" URL
