### PR TITLE
Fix SDK Quickstart links

### DIFF
--- a/templates/developer.rackspace.com/docs-home.html
+++ b/templates/developer.rackspace.com/docs-home.html
@@ -78,7 +78,7 @@
         </ul>
         <h5>SDK Language Support:</h5>
         <ul class="quickstarts">
-            <li><a href="/sdks/golang/" title="GO language support for Rackspace API services">Go</a></li>
+            <li><a href="/sdks/golang/" title="Go language support for Rackspace API services">Go</a></li>
             <li><a href="/sdks/java" title="Java language support for Rackspace API services">Java</a></li>
             <li><a href="/sdks/dot-net/" title=".NET language support for Rackspace API services">.NET</a></li>
             <li><a href="/sdks/node-js/" title="Node.js language support for Rackspace API services">Node.js</a></li>

--- a/templates/developer.rackspace.com/docs-home.html
+++ b/templates/developer.rackspace.com/docs-home.html
@@ -76,15 +76,15 @@
                 </a>
             </li>
         </ul>
-        <h5>Quickstart Guides:</h5>
+        <h5>SDK Language Support:</h5>
         <ul class="quickstarts">
-            <li><a href="/docs/cloud-servers/getting-started/" data-drc-language-selector="go">Go</a></li>
-            <li><a href="/docs/cloud-servers/getting-started/" data-drc-language-selector="java">Java</a></li>
-            <li><a href="/docs/cloud-servers/getting-started/" data-drc-language-selector="csharp">.NET</a></li>
-            <li><a href="/docs/cloud-servers/getting-started/" data-drc-language-selector="javascript">Node.js</a></li>
-            <li><a href="/docs/cloud-servers/getting-started/" data-drc-language-selector="php">PHP</a></li>
-            <li><a href="/docs/cloud-servers/getting-started/" data-drc-language-selector="python">Python</a></li>
-            <li><a href="/docs/cloud-servers/getting-started/" data-drc-language-selector="ruby">Ruby</a></li>
+            <li><a href="/sdks/golang/" title="GO language support for Rackspace API services">Go</a></li>
+            <li><a href="/sdks/java" title="Java language support for Rackspace API services">Java</a></li>
+            <li><a href="/sdks/dot-net/" title=".NET language support for Rackspace API services">.NET</a></li>
+            <li><a href="/sdks/node-js/" title="Node.js language support for Rackspace API services">Node.js</a></li>
+            <li><a href="/sdks/php/" title=".NET language support for Rackspace API services">PHP</a></li>
+            <li><a href="/sdks/python/" title="Python language support for Rackspace API services">Python</a></li>
+            <li><a href="/sdks/ruby/" title="Ruby language support for Rackspace API services">Ruby</a></li>
         </ul>
     </div>
 {% endblock %}

--- a/templates/developer.rackspace.com/docs-home.html
+++ b/templates/developer.rackspace.com/docs-home.html
@@ -82,7 +82,7 @@
             <li><a href="/sdks/java" title="Java language support for Rackspace API services">Java</a></li>
             <li><a href="/sdks/dot-net/" title=".NET language support for Rackspace API services">.NET</a></li>
             <li><a href="/sdks/node-js/" title="Node.js language support for Rackspace API services">Node.js</a></li>
-            <li><a href="/sdks/php/" title=".NET language support for Rackspace API services">PHP</a></li>
+            <li><a href="/sdks/php/" title="PHP language support for Rackspace API services">PHP</a></li>
             <li><a href="/sdks/python/" title="Python language support for Rackspace API services">Python</a></li>
             <li><a href="/sdks/ruby/" title="Ruby language support for Rackspace API services">Ruby</a></li>
         </ul>


### PR DESCRIPTION
- Change side menu title to SDK language support
- Update links to go to SDK getting started page for each language
- Add link title

@ktbartholomew   Can you check this PR which fixes issue #508.  I ask you because it is a template update, and I want to ensure I didn't break anything, and also that there aren't other connected pieces that might also require update.
