### PR TITLE
Add rpc-openstack repo to build list

### DIFF
--- a/config/content.d/staging.horse.json
+++ b/config/content.d/staging.horse.json
@@ -3,10 +3,14 @@
     "content": {
       "/docs/private-cloud/rpc/master/": "https://github.com/rackerlabs/docs-rpc/master/",
 <<<<<<< HEAD
+<<<<<<< HEAD
       "/docs/cloud-paas": "https://github.com/rackerlabs/docs-cloud-paas/",
       "/docs/api-doc-template/": "https://github.com/rackerlabs/docs-common/"
 =======
       "/docs/private-cloud/rpc/release-notes/": "https://github.com/rackerlabs/rpc-openstack/master/"
+=======
+      "/docs/private-cloud/rpc/release-notes/": "https://github.com/rackerlabs/rpc-openstack/master/",
+>>>>>>> 3f07120... Minor edit to staging.horse.json
       "/docs/cloud-paas": "https://github.com/rackerlabs/docs-cloud-paas/"
 
 >>>>>>> 033d514... Configure deploy URL and template route

--- a/config/content.d/staging.horse.json
+++ b/config/content.d/staging.horse.json
@@ -2,8 +2,14 @@
   "staging.horse": {
     "content": {
       "/docs/private-cloud/rpc/master/": "https://github.com/rackerlabs/docs-rpc/master/",
+<<<<<<< HEAD
       "/docs/cloud-paas": "https://github.com/rackerlabs/docs-cloud-paas/",
       "/docs/api-doc-template/": "https://github.com/rackerlabs/docs-common/"
+=======
+      "/docs/private-cloud/rpc/release-notes/": "https://github.com/rackerlabs/rpc-openstack/master/"
+      "/docs/cloud-paas": "https://github.com/rackerlabs/docs-cloud-paas/"
+
+>>>>>>> 033d514... Configure deploy URL and template route
     }
   }
 }

--- a/config/content.d/staging.horse.json
+++ b/config/content.d/staging.horse.json
@@ -2,18 +2,9 @@
   "staging.horse": {
     "content": {
       "/docs/private-cloud/rpc/master/": "https://github.com/rackerlabs/docs-rpc/master/",
-<<<<<<< HEAD
-<<<<<<< HEAD
+      "/docs/private-cloud/rpc/release-notes/": "https://github.com/rackerlabs/rpc-openstack/master/",
       "/docs/cloud-paas": "https://github.com/rackerlabs/docs-cloud-paas/",
       "/docs/api-doc-template/": "https://github.com/rackerlabs/docs-common/"
-=======
-      "/docs/private-cloud/rpc/release-notes/": "https://github.com/rackerlabs/rpc-openstack/master/"
-=======
-      "/docs/private-cloud/rpc/release-notes/": "https://github.com/rackerlabs/rpc-openstack/master/",
->>>>>>> 3f07120... Minor edit to staging.horse.json
-      "/docs/cloud-paas": "https://github.com/rackerlabs/docs-cloud-paas/"
-
->>>>>>> 033d514... Configure deploy URL and template route
     }
   }
 }

--- a/config/routes.d/staging.horse.json
+++ b/config/routes.d/staging.horse.json
@@ -2,6 +2,7 @@
   "staging.horse": {
     "routes": {
       "^/docs/private-cloud/": "developer.rackspace.com/user-guide.html",
+      "^/docs/private-cloud/release-notes/": "developer.rackspace.com/docs-singlepage.html",
       "^/docs/cloud-paas/": "developer.rackspace.com/user-guide.html",
       "^/docs/api-doc-template/": "developer.rackspace.com/user-guide.html"
     }

--- a/content-repositories.json
+++ b/content-repositories.json
@@ -5,6 +5,7 @@
   { "kind": "github", "project": "rackerlabs/docs-dedicated-vcloud" },
   { "kind": "github", "project": "rackerlabs/docs-redhat-osp" },
   { "kind": "github", "project": "rackerlabs/docs-rpc", "branches": ["master","v10", "v11", "v12"] },
+  { "kind": "github", "project": "rcbops/rpc-openstack", "branches": ["master"] },
   { "kind": "github", "project": "rackerlabs/rackspace-how-to" },
   { "kind": "github", "project": "rackerlabs/docs-core-infra-user-guide" },
   { "kind": "github", "project": "rackerlabs/docs-barbican" },


### PR DESCRIPTION
Add rpc-openstack repo to build  the Reno release notes. Addresses  https://github.com/rackerlabs/docs-workstream/issues/52
