### PR TITLE
Not needed - Add master branch to Cloud Servers

### DIFF
--- a/content-repositories.json
+++ b/content-repositories.json
@@ -27,7 +27,7 @@
   { "kind": "github", "project": "rackerlabs/docs-cloud-queues" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-rackconnect" },
   { "kind": "github", "project": "rackerlabs/docs-dedicated-networking" },
-  { "kind": "github", "project": "rackerlabs/docs-cloud-servers" },
+  { "kind": "github", "project": "rackerlabs/docs-cloud-servers", "branches": ["master"] },
   { "kind": "github", "project": "rackerlabs/docs-common"},
   { "kind": "github", "project": "rackerlabs/docs-rackspace" },
   { "kind": "github", "project": "rackerlabs/heat-resource-ref" },


### PR DESCRIPTION
Add master branch to Cloud Servers so that PR builder
uses the master branch on the PR to build rather than the
upstream master branch.

Possible fix for https://github.com/rackerlabs/docs-cloud-servers/issues/173.
