### PR TITLE
Fix CDN redirect

### DIFF
--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -55,7 +55,7 @@
  		  },
         {
             "description": "Redirect cdn developer-guide URL",
-            "from": "^\\/docs\\/cloud-cdn\\/v1\\/developer-guide\\/?(.*)$",
+            "from": "^\\/docs\\/cdn\\/v1\\/developer-guide\\/?(.*)$",
             "to": "/docs/cdn/v1/$1",
             "rewrite": false,
             "status": 301


### PR DESCRIPTION
Correct originating CDN path in redirect rule: `docs/cloud-cdn/developer-guide`
==> `docs/cdn/developer-guide\\`
