### PR TITLE
Configure redirect rule for rbac article

### DIFF
--- a/config/rewrites.d/support.rackspace.com.json
+++ b/config/rewrites.d/support.rackspace.com.json
@@ -38,6 +38,13 @@
           "status": 301
       },
       {
+          "description": "Getting started with Role-Based Access Control (RBAC)",
+          "from": "\\/how-to\\/getting-started-with-role-based-access-control-rbac-0(.*)$",
+          "to": "/how-to/getting-started-with-role-based-access-control-rbac/",
+          "rewrite": false,
+          "status": 301
+      },
+      {
         "description": "Redirect /knowledge_center/what-is-pci-compliance URL to /how-to/are-cloud-servers-pci-dss-compliant/",
         "from": "^\\/knowledge_center\\/article\\/what-is-pci-compliance(.*)$",
         "to": "/how-to/are-cloud-servers-pci-dss-compliant/",


### PR DESCRIPTION
Per e-mail from Mark Barta.

From: Nicole Schwartz
Sent: Friday, August 12, 2016 2:58 PM
To: Renee Rendon; Mark Barta; how-to@rackspace.com
Subject: RE: RBAC 404

I can put in a backlog bug yes

Thanks for letting us know
## 

Nicole Schwartz, Technical Product Manager IV
Rackspace Control Panel https://mycloud.rackspace.com/
(REACH)
Blacksburg VA Office (Eastern timezone)
Slack AmazonV
Vidyo x2922

From: Renee Rendon 
Sent: Friday, August 12, 2016 3:54 PM
To: Mark Barta mark.barta@rackspace.com; how-to@rackspace.com; Nicole Schwartz nicole.schwartz@RACKSPACE.COM
Subject: Re: RBAC 404

Hi Nicole,

Is this something that you guys can correct in the CP?

Thanks,
Renée
From: Mark Barta mark.barta@rackspace.com
Date: Friday, August 12, 2016 at 2:24 PM
To: "how-to@rackspace.com" How-To@rackspace.com
Subject: RBAC 404

Hi,

The RBAC article linked in MyCloud User Management errors out because there is “-0” added to the URL.

Bad Link - https://support.rackspace.com/how-to/getting-started-with-role-based-access-control-rbac-0/
Good Link - https://support.rackspace.com/how-to/getting-started-with-role-based-access-control-rbac/
