### PR TITLE
Remove user voice feedback redirect rule

### DIFF
--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -267,13 +267,6 @@
           "to": "/docs/$1/quickstart/$2",
           "rewrite": false,
           "status": 301
-        },
-                {
-          "description": "Redirect product feedback link https://feedback.rackspace.com/ to default community feedback link",
-          "from": "^\\/https://feedback.rackspace.com/?$",
-          "to": "https://community.rackspace.com/feedback/default/",
-          "rewrite:": false,
-          "status": 301
         }
     ]
 }

--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -270,7 +270,7 @@
         },
                 {
           "description": "Redirect product feedback link https://feedback.rackspace.com/ to default community feedback link",
-          "from": "https://feedback.rackspace.com/?$",
+          "from": "^\\/https://feedback.rackspace.com/?$",
           "to": "https://community.rackspace.com/feedback/default/",
           "rewrite:": false,
           "status": 301


### PR DESCRIPTION
@smashwilson  Trying to redirect the user voice feedback link for products to
 the default community link.  Can we do that using this rewrites file, and if so is the
syntax in this PR correct?
