### PR TITLE
Add RPCO v13 release notes to production builds

### DIFF
--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -32,6 +32,7 @@
           "/docs/cloud-feeds/v1/developer-guide/": "https://github.com/rackerlabs/standard-usage-schemas",
           "/docs/dedicated-load-balancers/v2/dev-guide/": "https://github.com/rackerlabs/docs-dedicated-networking/",
           "/docs/glossary/": "https://github.com/rackerlabs/docs-rackspace/",
+          "/docs/private-cloud/rpc/v13/release-notes": "https://github.com/rcbops/rpc-openstack/v13/",
           "/docs/private-cloud/rpc/v12/": "https://github.com/rackerlabs/docs-rpc/v12/",
           "/docs/private-cloud/rpc/v11": "https://github.com/rackerlabs/docs-rpc/v11/",
           "/docs/private-cloud/rpc/v10": "https://github.com/rackerlabs/docs-rpc/v10/",

--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -32,7 +32,7 @@
           "/docs/cloud-feeds/v1/developer-guide/": "https://github.com/rackerlabs/standard-usage-schemas",
           "/docs/dedicated-load-balancers/v2/dev-guide/": "https://github.com/rackerlabs/docs-dedicated-networking/",
           "/docs/glossary/": "https://github.com/rackerlabs/docs-rackspace/",
-          "/docs/private-cloud/rpc/v13/release-notes": "https://github.com/rcbops/rpc-openstack/v13/",
+          "/docs/private-cloud/release-notes/v13": "https://github.com/rcbops/rpc-openstack/v13/",
           "/docs/private-cloud/rpc/v12/": "https://github.com/rackerlabs/docs-rpc/v12/",
           "/docs/private-cloud/rpc/v11": "https://github.com/rackerlabs/docs-rpc/v11/",
           "/docs/private-cloud/rpc/v10": "https://github.com/rackerlabs/docs-rpc/v10/",

--- a/config/routes.d/developer.rackspace.com.json
+++ b/config/routes.d/developer.rackspace.com.json
@@ -41,6 +41,7 @@
             "^/docs/dedicated-load-balancers/v2/dev-guide/": "docs-singlepage.html",
             "^/docs/glossary": "docs-singlepage.html",
             "^/docs/private-cloud": "user-guide.html",
+            "^/docs/private-cloud/release-notes": "docs-singlepage.html",
             "^/docs/managed-vmware-services": "user-guide.html",
             "^/docs/rack-cli/": "rack-cli.html",
             "^/sdks": "sdks-home.html",

--- a/content-repositories.json
+++ b/content-repositories.json
@@ -5,7 +5,7 @@
   { "kind": "github", "project": "rackerlabs/docs-dedicated-vcloud" },
   { "kind": "github", "project": "rackerlabs/docs-redhat-osp" },
   { "kind": "github", "project": "rackerlabs/docs-rpc", "branches": ["master","v10", "v11", "v12"] },
-  { "kind": "github", "project": "rcbops/rpc-openstack", "branches": ["master"] },
+  { "kind": "github", "project": "rcbops/rpc-openstack", "branches": ["master","mitaka-13.0"] },
   { "kind": "github", "project": "rackerlabs/rackspace-how-to" },
   { "kind": "github", "project": "rackerlabs/docs-core-infra-user-guide" },
   { "kind": "github", "project": "rackerlabs/docs-barbican" },


### PR DESCRIPTION
1. Add mitaka branch to content.repositories.json
2. Update content.d to specify path
3. Update route.d with single-page template for release notes

Addresses https://github.com/rackerlabs/nexus-control/issues/566
