### PR TITLE
Change Barbican repo name to Cloud Keep

### DIFF
--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -28,7 +28,7 @@
           "/docs/metrics/v2/developer-guide/": "https://github.com/rackerlabs/docs-cloud-metrics/",
           "/docs/cloud-identity/v2/": "https://github.com/rackerlabs/docs-cloud-identity/",
           "/docs/rackspace-monitoring/v1/developer-guide/": "https://github.com/rackerlabs/docs-cloud-monitoring/",
-          "/docs/cloud-keep/v1/": "https://github.com/rackerlabs/docs-barbican/",
+          "/docs/cloud-keep/v1/": "https://github.com/rackerlabs/docs-cloud-keep/",
           "/docs/cloud-feeds/v1/developer-guide/": "https://github.com/rackerlabs/standard-usage-schemas",
           "/docs/dedicated-load-balancers/v2/dev-guide/": "https://github.com/rackerlabs/docs-dedicated-networking/",
           "/docs/glossary/": "https://github.com/rackerlabs/docs-rackspace/",

--- a/content-repositories.json
+++ b/content-repositories.json
@@ -8,7 +8,7 @@
   { "kind": "github", "project": "rcbops/rpc-openstack", "branches": ["master", "mitaka-13.0"] },
   { "kind": "github", "project": "rackerlabs/rackspace-how-to" },
   { "kind": "github", "project": "rackerlabs/docs-core-infra-user-guide" },
-  { "kind": "github", "project": "rackerlabs/docs-barbican" },
+  { "kind": "github", "project": "rackerlabs/docs-cloud-keep" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-backup" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-block-storage" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-cdn" },


### PR DESCRIPTION
Closes Cloud Keep [issue #75].
