### PR TITLE
redirect first gen servers to cloud-servers

### DIFF
--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -151,6 +151,13 @@
             "status": 301
         },
         {
+            "description": "Redirect first gen servers developer-guide URL",
+            "from": "^\\/docs\\/cloud-servers\\/v1.0\\/cs-devguide\\/(.*?)",
+            "to": "/docs/cloud-servers/v2/$1",
+            "rewrite": false,
+            "status": 301
+        },
+        {
             "description": "Redirect images developer-guide URL",
             "from": "^\\/docs\\/cloud-images\\/v2\\/developer-guide\\/(.*?)",
             "to": "/docs/cloud-images/v2/$1",


### PR DESCRIPTION
hopefully once this merges on 9/15, anyone going to old fg docs will get shunted to cloud-servers docs instead.
