### PR TITLE
Add docs-support-network to list of strider builds

### DIFF
--- a/content-repositories.json
+++ b/content-repositories.json
@@ -29,6 +29,7 @@
   { "kind": "github", "project": "rackerlabs/docs-dedicated-networking" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-servers" },
   { "kind": "github", "project": "rackerlabs/docs-common"},
+  { "kind": "github", "project": "rackerlabs/docs-support-network"},
   { "kind": "github", "project": "rackerlabs/docs-rackspace" },
   { "kind": "github", "project": "rackerlabs/heat-resource-ref" },
   { "kind": "github", "project": "rackerlabs/otter" },


### PR DESCRIPTION
If the docs-support-network repo builds from Strider, we should be able to make changes to support.rackspace.com homepage.
