### PR TITLE
Add bolditalic styling for RST

### DIFF
--- a/assets/src/css/less/typography.less
+++ b/assets/src/css/less/typography.less
@@ -25,6 +25,11 @@ strong, b {
     }
 }
 
+// enable bolditalic for RST
+.bolditalic {
+    .open-sans('bold','italic');
+}
+
 a {
     color: @link-color;
     cursor: pointer;


### PR DESCRIPTION
RST cannot produce bold+italic by nesting markup. We can
workaround this by defining a bolditalic role that translates
to an HTML class, then style the class as needed.

This patch defines the styling for the bolditalic class.

Partial: rackerlabs/docs-workstream#123
