### PR TITLE
Correct filter selector label for Data & Storage

### DIFF
--- a/templates/developer.rackspace.com/docs-home.html
+++ b/templates/developer.rackspace.com/docs-home.html
@@ -39,6 +39,12 @@
                     <span class="indicator fa fa-check"></span>
                 </a>
             </li>
+            <li class="" data-ng-click="clickFilter('cloud')" data-ng-class="{'active': isFilterActive('cloud')}">
+                <a href="">
+                    <span class="label">Cloud</span>
+                    <span class="indicator fa fa-check"></span>
+                </a>
+            </li>
             <li class="compute" data-ng-click="clickFilter('compute')" data-ng-class="{'active': isFilterActive('compute')}">
                 <a href="">
                     <span class="label">Compute</span>
@@ -51,15 +57,9 @@
                     <span class="indicator fa fa-check"></span>
                 </a>
             </li>
-            <li class="storage" data-ng-click="clickFilter('storage')" data-ng-class="{'active': isFilterActive('storage')}">
+            <li class="storagedata" data-ng-click="clickFilter('storagedata')" data-ng-class="{'active': isFilterActive('storagedata')}">
                 <a href="">
-                    <span class="label">Storage</span>
-                    <span class="indicator fa fa-check"></span>
-                </a>
-            </li>
-            <li class="data" data-ng-click="clickFilter('data')" data-ng-class="{'active': isFilterActive('data')}">
-                <a href="">
-                    <span class="label">Data</span>
+                    <span class="label">Storage &amp; Data</span>
                     <span class="indicator fa fa-check"></span>
                 </a>
             </li>


### PR DESCRIPTION
Fixes [docs-workstream issue #73](https://github.com/rackerlabs/docs-workstream/issues/73)
to improve visibility of Private Cloud docs.

Update doc type selector menu in left navigation to match docs landing
page updates.
- Add Cloud selector filter
- Combine Data and Storage filter

Combined Data and Storage categories to maintain same length for selector
menu.
