### PR TITLE
Add styling for Sphinx roles

### DIFF
--- a/assets/src/css/less/typography.less
+++ b/assets/src/css/less/typography.less
@@ -25,9 +25,17 @@ strong, b {
     }
 }
 
-// enable bolditalic for RST
+// styling for Sphinx roles
 .bolditalic {
     .open-sans('bold','italic');
+}
+
+.guilabel {
+    .open-sans('bold');
+}
+
+.menuselection {
+    .open-sans('bold');
 }
 
 a {


### PR DESCRIPTION
guilabel and menuselection are standard Sphinx
roles but they do not have a default styling.

Set the styling for both roles to bold.

rackerlabs/docs-workstream#89
