### PR TITLE
RSWEB-7678 - GA/GTM implementation - support.rackspace.com

### DIFF
--- a/templates/support.rackspace.com/_includes/gtm-noscript.html
+++ b/templates/support.rackspace.com/_includes/gtm-noscript.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MW68KW"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/templates/support.rackspace.com/_includes/gtm-script.html
+++ b/templates/support.rackspace.com/_includes/gtm-script.html
@@ -1,0 +1,10 @@
+<!-- Google Tag Manager -->
+<script>
+dataLayer = [];
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MW68KW');
+</script>
+<!-- End Google Tag Manager -->

--- a/templates/support.rackspace.com/_layouts/raw.html
+++ b/templates/support.rackspace.com/_layouts/raw.html
@@ -12,23 +12,14 @@
 
         <link rel="canonical" href="{{ siteUrl }}">
         <link rel="stylesheet" href="{{ cssUrl }}">
-
+        {% include "_includes/gtm-script.html" %}
         <script src="https://c4d62906a15616653758-49dececd4e3f03377b7f33fac7abfae8.ssl.cf5.rackcdn.com/prod/raxheaderservice.js"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
         <script type="text/javascript" src="{{ jsUrl }}"></script>
     {% endblock %}
 </head>
 <body>
+  {% include "_includes/gtm-noscript.html" %}
   {% block body %}{% endblock %}
-        <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-81189538-1', 'auto');
-        ga('send', 'pageview');
-
-        </script>
 </body>
 </html>


### PR DESCRIPTION
This PR pivots https://support.rackspace.com to Google Tag Manager.
- Remove legacy GA snippet
- Add GTM snippets in appropriate document locations
