### PR TITLE
Remove Cloud Keep configuration

### DIFF
--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -28,7 +28,6 @@
           "/docs/metrics/v2/": "https://github.com/rackerlabs/docs-cloud-metrics/",
           "/docs/cloud-identity/v2/": "https://github.com/rackerlabs/docs-cloud-identity/",
           "/docs/rackspace-monitoring/v1/": "https://github.com/rackerlabs/docs-cloud-monitoring/",
-          "/docs/cloud-keep/v1/": "https://github.com/rackerlabs/docs-cloud-keep/",
           "/docs/cloud-feeds/v1/developer-guide/": "https://github.com/rackerlabs/standard-usage-schemas",
           "/docs/dedicated-load-balancers/v2/": "https://github.com/rackerlabs/docs-dedicated-networking/",
           "/docs/glossary/": "https://github.com/rackerlabs/docs-rackspace/",

--- a/config/routes.d/developer.rackspace.com.json
+++ b/config/routes.d/developer.rackspace.com.json
@@ -36,7 +36,6 @@
             "^/docs/metrics/v2/": "user-guide.html",
             "^/docs/cloud-identity/v2/": "user-guide.html",
             "^/docs/rackspace-monitoring/v1/": "user-guide.html",
-            "^/docs/cloud-keep/v1/": "user-guide.html",
             "^/docs/cloud-feeds/v1/developer-guide/": "docs-singlepage.html",
             "^/docs/dedicated-load-balancers/v2/": "user-guide.html",
             "^/docs/glossary": "docs-singlepage.html",

--- a/content-repositories.json
+++ b/content-repositories.json
@@ -8,7 +8,6 @@
   { "kind": "github", "project": "rcbops/rpc-openstack", "branches": ["master", "mitaka-13.0"] },
   { "kind": "github", "project": "rackerlabs/rackspace-how-to" },
   { "kind": "github", "project": "rackerlabs/docs-core-infra-user-guide" },
-  { "kind": "github", "project": "rackerlabs/docs-cloud-keep" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-backup" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-block-storage" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-cdn" },


### PR DESCRIPTION
API is deprecated.
Closes issue https://github.com/rackerlabs/docs-cloud-keep/issues/78.