### PR TITLE
retiring RBAC matrix for Cloud Big Data v1

### DIFF
--- a/config/rewrites.d/support.rackspace.com.json
+++ b/config/rewrites.d/support.rackspace.com.json
@@ -442,6 +442,13 @@
         "to": "/how-to/article-retired/",
         "rewrite": false,
         "status": 301
+      },
+          {
+        "description": "Retire detailed permissions matrix for Cloud Big Data v1",
+        "from": "^\\/how-to\\/detailed-permissions-matrix-for-cloud-big-data(.*)$",
+        "to": "/how-to/article-retired/",
+        "rewrite": false,
+        "status": 301
       }
     ]
 }


### PR DESCRIPTION
rewrite to retired. For details, see rackerlabs/rackspace-how-to#1711