### PR TITLE
Fix Orchestration and RackConnect redirect rules

### DIFF
--- a/config/rewrites.d/docs.rackspace.com.json
+++ b/config/rewrites.d/docs.rackspace.com.json
@@ -209,7 +209,7 @@
 		},
 		{
 			"description": "orchestration templates user guide",
-			"from": "^/orchestration/api/v1/orchestration-templates-devguide",
+			"from": "^/orchestration/api/v1/orchestration-templates-devguide/?(.*)$",
 			"to": "/docs/user-guides/orchestration/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -228,9 +228,9 @@
 		{
 			"description": "Rackconnect",
 			"from": "^/rackconnect/api/v3/?(.*)$",
-			"to": "http://docs.rcv3.apiary.io/",
+			"to": "https://docs.rcv3.apiary.io/",
 			"toProtocol": "https",
-			"toHostname": "developer.rackspace.com",
+			"toHostname": "docs-rcv3.apiary.io",
 			"rewrite": false,
 			"status": 301
 		},


### PR DESCRIPTION
- Add wildcard pattern to Orchestration user guide redirect rule
- Fix hostname for the RackConnect redirect target