### PR TITLE
Add redirects for REACH deep links

### DIFF
--- a/config/rewrites.d/docs.rackspace.com.json
+++ b/config/rewrites.d/docs.rackspace.com.json
@@ -12,7 +12,7 @@
 		{
 			"description": "autoscale",
 			"from": "^/cas/api/v1.0/autoscale-devguide/?(.*)$",
-			"to": "/docs/autoscale/v1/developer-guide/#document-index",
+			"to": "/docs/autoscale/v1/developer-guide/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
@@ -246,7 +246,7 @@
 		{
 			"description": "cloud servers",
 			"from": "^/servers/api/v2/?(.*)$",
-			"to": "/docs/#docs-cloud-servers-legacy",
+			"to": "/docs/cloud-servers/v2/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
@@ -255,7 +255,7 @@
 		{
 			"description": "Rackspace Private Cloud Operator and User Guide, v10",
 			"from": "^/rpc/api/v10/bk-rpc-guide",
-			"to": "/docs/private-cloud/rpc/v10rpc-v10-op-user-guide/rpc-access/",
+			"to": "/docs/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,

--- a/config/rewrites.d/docs.rackspace.com.json
+++ b/config/rewrites.d/docs.rackspace.com.json
@@ -9,6 +9,33 @@
 			"rewrite": false,
 			"status": 302
 		},
+			{
+			"description": "Configuring RackConnect dedicated load balancers",
+			"from": "^/cas/api/v1.0/autoscale-devguide/content/autoscale-groups.html",
+			"to": "https://support.rackspace.com/how-to/using-dedicated-load-balancers-with-rackconnect-v20/",
+			"toProtocol": "https",
+			"toHostname": "support.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "REACH autoscale getting started link",
+			"from": "^cas/api/v1.0/autoscale-gettingstarted/content/Overview.html",
+			"to": "/docs/autoscale/v1/developer-guide/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "REACH autoscale create webhook policies link",
+			"from": "^/cas/api/v1.0/autoscale-devguide/content/POST_createPolicies_v1.0__tenantId__groups__groupId__policies_autoscale-policies.html",
+			"to": "https://support.rackspace.com/how-to/configure-rackspace-auto-scale-web-hooks-with-rackspace-monitoring/",
+			"toProtocol": "https",
+			"toHostname": "support.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
 		{
 			"description": "autoscale",
 			"from": "^/cas/api/v1.0/autoscale-devguide/?(.*)$",
@@ -22,6 +49,15 @@
 			"description": "cloud backup",
 			"from": "^/rcbu/api/v1.0/rcbu-devguide/?(.*)$",
 			"to": "/docs/cloud-backup/v1/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "cloud big data v2",
+			"from": "^/cbd/api/v1.0/cbd-devguide-2/content/overview.html",
+			"to": "/docs/cloud-big-data/v2/getting-started/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
@@ -64,9 +100,18 @@
 			"status": 301
 		},
 		{
+			"description": "REACH cloud databases instance status link",
+			"from": "^/cdb/api/v1.0/cdb-devguide/content/database_instance_status.html",
+			"to": "/docs/cloud-databases/v1/general-api-info/database-instance-status/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
 			"description": "cloud databases",
 			"from": "^/cdb/api/v1.0/?(.*)$",
-			"to": "/docs/cloud-databases/v1/",
+			"to": "/docs/cloud-databases/v2/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
@@ -118,6 +163,16 @@
 			"status": 301
 		},
 		{
+			"description": "REACH List cloud load balancers link",
+			"from": "^/loadbalancers/api/v1.0/clb-devguide/content/List_Usage-d1e3014.html",
+			"to": "/docs/cloud-load-balancers/v1/api-reference/load-balancers/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		
+		{
 			"description": "cloud load balancers",
 			"from": "^/loadbalancers/api/v1.0/?(.*)$",
 			"to": "/docs/cloud-load-balancers/v1/",
@@ -136,9 +191,27 @@
 			"status": 301
 		},
 		{
+			"description": "Reach Cloud Monitoring set up notificationstutorial link",
+			"from": "^/cm/api/v1.0/cm-getting-started/content/concepts-tutorial-setup-notifications.html",
+			"to": "/docs/rackspace-monitoring/v1/getting-started/create-first-monitor/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
 			"description": "Reach Cloud Monitoring Alerts/Langauge Link",
 			"from": "^/cm/api/v1.0/cm-devguide/content/alerts-language.html",
-			"to": "/docs/rackspace-monitoring/v1/tech-ref-info/alert-triggers-and-alarms",
+			"to": "e",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "Reach Cloud Monitoring remote check type body match link",
+			"from": "^/cm/api/v1.0/cm-devguide//content/service-check-types.html#section-check-types-remote.http",
+			"to": "/docs/rackspace-monitoring/v1/tech-ref-info/check-type-reference/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
@@ -199,6 +272,24 @@
 			"status": 301
 		},
 		{
+			"description": "REACH cloud networks security groups API reference link",
+			"from": "^/networks/api/v2/cn-devguide/content/api_ext_security_neutron.html",
+			"to": "/docs/cloud-networks/v2/api-reference/sec-group-operations/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "REACH cloud networks security groups getting started link",
+			"from": "^/networks/api/v2/cn-gettingstarted/content/security_groups.html",
+			"to": "/docs/cloud-networks/v2/getting-started/controlling-network-access/security-groups/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
 			"description": "cloud networks",
 			"from": "^/networks/api/v2/?(.*)$",
 			"to": "/docs/cloud-networks/v2/",
@@ -208,7 +299,6 @@
 			"status": 301
 		},
 		{
-<<<<<<< HEAD
 			"description": "orchestration templates user guide template topic redirect for REACH",
 			"from": "^/orchestration/api/v1/orchestration-templates-devguide//content/Defining_Template_dle245.html?(.*)$",
 			"to": "/docs/user-guides/orchestration/generic-software-config/",
@@ -218,7 +308,7 @@
 			"status": 301
 		},
 		{
-			"description": "orchestration templates user guide template topic redirect for REACH",
+			"description": "orchestration templates user guide simple template topic redirect for REACH",
 			"from": "^/orchestration/api/v1/orchestration-templates-devguide/content/Simple_Template_Example-d1e637.html?(.*)$",
 			"to": "/docs/user-guides/orchestration/generic-software-config/",
 			"toProtocol": "https",
@@ -227,13 +317,9 @@
 			"status": 301
 		},		
 		{
-			"description": "orchestration templates user guide",
-			"from": "^/orchestration/api/v1/orchestration-templates-devguide/?(.*)$",
-=======
-			"description": "orchestration templates user guide",
-			"from": "^/orchestration/api/v1/orchestration-templates-devguide",
->>>>>>> 5ac5df6cdf4f4f0212077e46fcae06c0df7b2516
-			"to": "/docs/user-guides/orchestration/",
+			"description": "REACH orchestration concepts link",
+			"from": "^/orchestration/api/v1/orchestration-devguide/content/Concepts-d1e565.html",
+			"to": "/docs/cloud-orchestration/v1/getting-started/concepts/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
@@ -251,15 +337,9 @@
 		{
 			"description": "Rackconnect",
 			"from": "^/rackconnect/api/v3/?(.*)$",
-<<<<<<< HEAD
 			"to": "https://docs.rcv3.apiary.io/",
 			"toProtocol": "https",
 			"toHostname": "docs-rcv3.apiary.io",
-=======
-			"to": "http://docs.rcv3.apiary.io/",
-			"toProtocol": "https",
-			"toHostname": "developer.rackspace.com",
->>>>>>> 5ac5df6cdf4f4f0212077e46fcae06c0df7b2516
 			"rewrite": false,
 			"status": 301
 		},
@@ -267,6 +347,33 @@
 			"description": "cloud servers legacy",
 			"from": "^/servers/api/v1.0/?(.*)$",
 			"to": "/docs/cloud-servers/v2/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "REACH cloud servers rate limits link",
+			"from": "^/servers/api/v2/cs-devguide/content/Rate_Limits-d1e862.html",
+			"to": "/docs/cloud-servers/v2/general-api-info/limits/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "REACH cloud servers absolute rate limits link",
+			"from": "^/servers/api/v2/cs-devguide/content/Absolute_Limits-d1e994.html",
+			"to":  "/docs/cloud-servers/v2/general-api-info/limits/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "REACH cloud servers programmatic rate limits link",
+			"from": "^/servers/api/v2/cs-devguide/content/ProgrammaticLimits.html",
+			"to":  "docs/cloud-servers/v2/api-reference/svr-misc-operations/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,

--- a/config/rewrites.d/docs.rackspace.com.json
+++ b/config/rewrites.d/docs.rackspace.com.json
@@ -10,9 +10,18 @@
 			"status": 302
 		},
 		{
-			"description": "cloud servers legacy",
-			"from": "^/servers/api/v1.0/cs-devguide",
-			"to": "/docs/#docs-cloud-servers-legacy",
+			"description": "autoscale",
+			"from": "^\\/cas\\/api\\/v1.0\\/autoscale-devguide\\/?(.*)$",
+			"to": "/docs/autoscale/v1/developer-guide/#document-index",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "cloud backup",
+			"from": "^\\/rcbu\\/api\\/v1.0\\/rcbu-devguide\\/?(.*)$",
+			"to": "/docs/cloud-backup/v1/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
@@ -21,16 +30,52 @@
 		{
 			"description": "cloud big data v1",
 			"from": "^/cbd/api/v1.0/cbd-devguide",
-			"to": "/docs/cloud-big-data/v2/developer-guide/#release-notes",
+			"to": "/docs/cloud-big-data/v2/release-notes/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
 			"status": 301
 		},
 		{
-			"description": "orchestration templates user guide",
-			"from": "^/orchestration/api/v1/orchestration-templates-devguide",
-			"to": "/docs/user-guides/orchestration/",
+			"description": "cloud big data",
+			"from": "^\\/cbd\\/api\\/v1.0\\/?(.*)$",
+			"to": "/docs/cloud-big-data/v2/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "cloud block storage",
+			"from": "^\\/cbs\\/api\\/v1.0\\/?(.*)$",
+			"to": "/docs/cloud-block-storage/v1/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "CDN",
+			"from": "^/cdn/api/v1.0\\/?(.*)$",
+			"to": "/docs/cdn/v1/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "cloud databases",
+			"from": "^\\/cdb\\/api\\/v1.0\\/?(.*)$",
+			"to": "/docs/cloud-databases/v1/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "cloud DNS",
+			"from": "^\\/cdns\\/api\\/v1.0\\/?(.*)$",
+			"to": "docs/cloud-dns/v1/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
@@ -46,18 +91,45 @@
 			"status": 301
 		},
 		{
-			"description": "Rackspace Private Cloud Operator and User Guide, v10",
-			"from": "^/rpc/api/v10/bk-rpc-guide",
-			"to": "/docs/private-cloud/rpc/v10rpc-v10-op-user-guide/rpc-access/",
+			"description": "cloud files",
+			"from": "^\\/files\\/api\\/v1\\/?(.*)$",
+			"to": "/docs/cloud-files/v1/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
 			"status": 301
 		},
 		{
-			"description": "Rackspace Private Cloud Powered by Red Hat Features and Architecture",
-			"from": "^/rpc/api/rh1/bk-rpcr-refarch",
-			"to": "/docs/private-cloud/red-hat/rpcr-arch/",
+			"description": "cloud identity",
+			"from": "^\\/auth\\/api\\/v2.0\\/?(.*)$",
+			"to": "/docs/cloud-identity/v2/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "cloud images",
+			"from": "^\\/images\\/api\\/v2\\/?(.*)$",
+			"to": "/docs/cloud-images/v2/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "cloud load balancers",
+			"from": "^\\/loadbalancers\\/api\\/v1.0\\/?(.*)$",
+			"to": "/docs/cloud-load-balancers/v1/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "Cloud Metrics",
+			"from": "^\\/cmet\\/api\\/v1.0\\/?(.*)$",
+			"to": "/docs/metrics/v2/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
@@ -102,7 +174,7 @@
 	        {
 			"description": "Reach Cloud Monitoring Data Granularity Link",
 			"from": "^/cm/api/v1.0/cm-devguide/content/metrics-api.html#metrics-data-granularity",
-			"to": "/docs/rackspace-monitoring/v1/api-reference/metrics-operations/#data",
+			"to": "/docs/rackspace-monitoring/v1/api-reference/metrics-operations",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
@@ -111,7 +183,7 @@
 	        {
 			"description": "Reach Cloud Monitoring Metrics API Link",
 			"from": "^/cm/api/v1.0/cm-devguide/content/metrics-api.html",
-			"to": "/docs/rackspace-monitoring/v1/api-reference/metrics-operations/#metrics-api-operations",
+			"to": "/docs/rackspace-monitoring/v1/api-reference/metrics-operations/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,
@@ -121,6 +193,78 @@
 			"description": "Cloud Monitoring Developer Guide",
 			"from": "^/cm",
 			"to": "/docs/rackspace-monitoring/v1/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "cloud networks",
+			"from": "^\\/networks\\/api\\/v2\\/?(.*)$",
+			"to": "/docs/cloud-networks/v2/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "orchestration templates user guide",
+			"from": "^/orchestration/api/v1/orchestration-templates-devguide",
+			"to": "/docs/user-guides/orchestration/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "orchestration API",
+			"from": "^\\/orchestration\\/api\\/v1\\/?(.*)$",
+			"to": "/docs/cloud-orchestration/v1/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "Rackconnect",
+			"from": "^\\/rackconnect\\/api\\/v3\\/?(.*)$",
+			"to": "http://docs.rcv3.apiary.io/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "cloud servers legacy",
+			"from": "^\\/servers\\/api\\/v1.0\\/?(.*)$",
+			"to": "/docs/cloud-servers/v2/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "cloud servers",
+			"from": "^\\/servers\\/api\\/v2\\/?(.*)$",
+			"to": "/docs/#docs-cloud-servers-legacy",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "Rackspace Private Cloud Operator and User Guide, v10",
+			"from": "^/rpc/api/v10/bk-rpc-guide",
+			"to": "/docs/private-cloud/rpc/v10rpc-v10-op-user-guide/rpc-access/",
+			"toProtocol": "https",
+			"toHostname": "developer.rackspace.com",
+			"rewrite": false,
+			"status": 301
+		},
+		{
+			"description": "Rackspace Private Cloud Powered by Red Hat Features and Architecture",
+			"from": "^/rpc/api/rh1/bk-rpcr-refarch",
+			"to": "/docs/private-cloud/red-hat/rpcr-arch/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,

--- a/config/rewrites.d/docs.rackspace.com.json
+++ b/config/rewrites.d/docs.rackspace.com.json
@@ -11,7 +11,7 @@
 		},
 		{
 			"description": "autoscale",
-			"from": "^\\/cas\\/api\\/v1.0\\/autoscale-devguide\\/?(.*)$",
+			"from": "^/cas/api/v1.0/autoscale-devguide/?(.*)$",
 			"to": "/docs/autoscale/v1/developer-guide/#document-index",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -20,7 +20,7 @@
 		},
 		{
 			"description": "cloud backup",
-			"from": "^\\/rcbu\\/api\\/v1.0\\/rcbu-devguide\\/?(.*)$",
+			"from": "^/rcbu/api/v1.0/rcbu-devguide/?(.*)$",
 			"to": "/docs/cloud-backup/v1/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -38,7 +38,7 @@
 		},
 		{
 			"description": "cloud big data",
-			"from": "^\\/cbd\\/api\\/v1.0\\/?(.*)$",
+			"from": "^/cbd/api/v1.0/?(.*)$",
 			"to": "/docs/cloud-big-data/v2/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -47,7 +47,7 @@
 		},
 		{
 			"description": "cloud block storage",
-			"from": "^\\/cbs\\/api\\/v1.0\\/?(.*)$",
+			"from": "^/cbs/api/v1.0/?(.*)$",
 			"to": "/docs/cloud-block-storage/v1/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -56,7 +56,7 @@
 		},
 		{
 			"description": "CDN",
-			"from": "^/cdn/api/v1.0\\/?(.*)$",
+			"from": "^/cdn/api/v1.0/?(.*)$",
 			"to": "/docs/cdn/v1/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -65,7 +65,7 @@
 		},
 		{
 			"description": "cloud databases",
-			"from": "^\\/cdb\\/api\\/v1.0\\/?(.*)$",
+			"from": "^/cdb/api/v1.0/?(.*)$",
 			"to": "/docs/cloud-databases/v1/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -74,7 +74,7 @@
 		},
 		{
 			"description": "cloud DNS",
-			"from": "^\\/cdns\\/api\\/v1.0\\/?(.*)$",
+			"from": "^/cdns/api/v1.0/?(.*)$",
 			"to": "docs/cloud-dns/v1/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -92,7 +92,7 @@
 		},
 		{
 			"description": "cloud files",
-			"from": "^\\/files\\/api\\/v1\\/?(.*)$",
+			"from": "^/files/api/v1/?(.*)$",
 			"to": "/docs/cloud-files/v1/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -101,7 +101,7 @@
 		},
 		{
 			"description": "cloud identity",
-			"from": "^\\/auth\\/api\\/v2.0\\/?(.*)$",
+			"from": "^/auth/api/v2.0/?(.*)$",
 			"to": "/docs/cloud-identity/v2/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -110,7 +110,7 @@
 		},
 		{
 			"description": "cloud images",
-			"from": "^\\/images\\/api\\/v2\\/?(.*)$",
+			"from": "^/images/api/v2/?(.*)$",
 			"to": "/docs/cloud-images/v2/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -119,7 +119,7 @@
 		},
 		{
 			"description": "cloud load balancers",
-			"from": "^\\/loadbalancers\\/api\\/v1.0\\/?(.*)$",
+			"from": "^/loadbalancers/api/v1.0/?(.*)$",
 			"to": "/docs/cloud-load-balancers/v1/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -128,7 +128,7 @@
 		},
 		{
 			"description": "Cloud Metrics",
-			"from": "^\\/cmet\\/api\\/v1.0\\/?(.*)$",
+			"from": "^/cmet/api/v1.0/?(.*)$",
 			"to": "/docs/metrics/v2/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -200,7 +200,7 @@
 		},
 		{
 			"description": "cloud networks",
-			"from": "^\\/networks\\/api\\/v2\\/?(.*)$",
+			"from": "^/networks/api/v2/?(.*)$",
 			"to": "/docs/cloud-networks/v2/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -218,7 +218,7 @@
 		},
 		{
 			"description": "orchestration API",
-			"from": "^\\/orchestration\\/api\\/v1\\/?(.*)$",
+			"from": "^/orchestration/api/v1/?(.*)$",
 			"to": "/docs/cloud-orchestration/v1/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -227,7 +227,7 @@
 		},
 		{
 			"description": "Rackconnect",
-			"from": "^\\/rackconnect\\/api\\/v3\\/?(.*)$",
+			"from": "^/rackconnect/api/v3/?(.*)$",
 			"to": "http://docs.rcv3.apiary.io/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -236,7 +236,7 @@
 		},
 		{
 			"description": "cloud servers legacy",
-			"from": "^\\/servers\\/api\\/v1.0\\/?(.*)$",
+			"from": "^/servers/api/v1.0/?(.*)$",
 			"to": "/docs/cloud-servers/v2/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
@@ -245,7 +245,7 @@
 		},
 		{
 			"description": "cloud servers",
-			"from": "^\\/servers\\/api\\/v2\\/?(.*)$",
+			"from": "^/servers/api/v2/?(.*)$",
 			"to": "/docs/#docs-cloud-servers-legacy",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",

--- a/config/rewrites.d/docs.rackspace.com.json
+++ b/config/rewrites.d/docs.rackspace.com.json
@@ -202,7 +202,7 @@
 		{
 			"description": "Reach Cloud Monitoring Alerts/Langauge Link",
 			"from": "^/cm/api/v1.0/cm-devguide/content/alerts-language.html",
-			"to": "e",
+			"to": "/docs/rackspace-monitoring/v1/tech-ref-info/alert-triggers-and-alarms/",
 			"toProtocol": "https",
 			"toHostname": "developer.rackspace.com",
 			"rewrite": false,


### PR DESCRIPTION
Added redirects for topic-specific links in REACH so that users go to the right topic for the information instead of being redirected to top of API Guide.