### PR TITLE
Update deconst config to publish RPC engineering handbook

### DIFF
--- a/config/content.d/staging.horse.json
+++ b/config/content.d/staging.horse.json
@@ -1,8 +1,8 @@
 {
   "staging.horse": {
     "content": {
+      "/docs-private-cloud/eng-handbook/": "https://github.com/rackerlabs/docs-rpc/handbook/",
       "/docs/private-cloud/rpc/master/": "https://github.com/rackerlabs/docs-rpc/master/",
-      "/docs/private-cloud/rpc/internal/": "https://github.com/rackerlabs/docs-rpc/internal/",
       "/docs/private-cloud/release-notes/": "https://github.com/rcbops/rpc-openstack/master/",
       "/docs/cloud-paas": "https://github.com/rackerlabs/docs-cloud-paas/",
       "/docs/api-doc-template/": "https://github.com/rackerlabs/docs-common/"

--- a/config/routes.d/staging.horse.json
+++ b/config/routes.d/staging.horse.json
@@ -1,6 +1,7 @@
 {
   "staging.horse": {
     "routes": {
+      "^/docs/private-cloud/eng-handbook/": "developer.rackspace.com/user-guide.html",
       "^/docs/private-cloud/": "developer.rackspace.com/user-guide.html",
       "^/docs/private-cloud/release-notes/": "developer.rackspace.com/docs-singlepage.html",
       "^/docs/cloud-paas/": "developer.rackspace.com/user-guide.html",


### PR DESCRIPTION
Publish RPC engineering handbook to the staging.horse.deconst development server.
Work component of the following issue:  https://github.com/rackerlabs/docs-rpc/issues/808