### PR TITLE
Redirect RPC to v13

### DIFF
--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -305,13 +305,6 @@
           "status": 301
         },
         {
-          "description": "Redirect RPC URL to current version",
-          "from": "^/docs/private-cloud/rpc/?$",
-          "to": "/docs/private-cloud/rpc/v12",
-          "rewrite:": false,
-          "status": 301
-        },        
-        {
           "description": "Redirect RPC Admin URL to OpenStack Admin Guide",
           "from": "^/docs/private-cloud/rpc/([a-zA-Z0-9%_-]*)/rpc-admin/?(.*)$",
           "to": "http://docs.openstack.org/admin-guide/index.html",


### PR DESCRIPTION
Remove RPC redirect to v12, which is no longer the latest version of RPC. This entry was preventing the later v13 redirect entry from taking effect.