### PR TITLE
Redirect /betadocs to live site

### DIFF
--- a/config/rewrites.d/getcarina.com.json
+++ b/config/rewrites.d/getcarina.com.json
@@ -18,8 +18,7 @@
         },
         {
             "from": "\\/betadocs\\/(.*)$",
-            "to": "/getcarina.com/build-53414681f4/$1",
-            "toHostname": "staging.developer.rackspace.com",
+            "to": "/$1",
             "rewrite": false,
             "status": 302
         },


### PR DESCRIPTION
Now that the beta is over, we need to keep this around because people
will still have those old links.