### PR TITLE
Fix redirects for API Guides

### DIFF
--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -64,35 +64,35 @@
         {
             "description": "Redirect cdn developer-guide URL",
             "from": "^\\/docs\\/cdn\\/v1\\/developer-guide\\/?(.*)$",
-            "to": "/docs/cdn/v1/$1",
+            "to": "/docs/cdn/v1/",
             "rewrite": false,
             "status": 301
         },
         {
           "description": "Redirect managed dns developer-guide URL",
           "from": "^\\/docs\\/cloud-dns\\/v2\\/developer-guide\\/(.*?)",
-          "to": "/docs/cloud-dns/v2/$1",
+          "to": "/docs/cloud-dns/v2/",
           "rewrite": false,
           "status": 301
         },
        {
           "description": "Redirect cloud big data developer-guide URL",
           "from": "^\\/docs\\/cloud-big-data\\/v2\\/developer-guide\\/(.*?)",
-          "to": "/docs/cloud-big-data/v2/$1",
+          "to": "/docs/cloud-big-data/v2/",
           "rewrite": false,
           "status": 301
         },
         {
           "description": "Redirect cloud dns developer-guide URL",
           "from": "^\\/docs\\/cloud-dns\\/v1\\/developer-guide\\/(.*?)",
-          "to": "/docs/cloud-dns/v1/$1",
+          "to": "/docs/cloud-dns/v1/",
           "rewrite": false,
           "status": 301
         },
         {
           "description": "Redirect common annotated auth resp URL",
           "from": "^\\/docs\\/cloud-identity\\/v2\\/developer-guide\\/#document-authentication-info\\/sample-auth-req-response(.*?)",
-          "to": "/docs/cloud-identity/v2/general-api-info/authentication-info/sample-auth-req-response/#annotated-authentication-request-and-response",
+          "to": "/docs/cloud-identity/v2/general-api-info/authentication-info/sample-auth-req-response/",
           "rewrite": false,
           "status": 301
         },
@@ -113,194 +113,187 @@
         {
           "description": "Redirect common RBAC add user URL",
           "from": "^\\/docs\\/cloud-identity\\/v2\\/developer-guide\\/#add-user\\/?(.*)$",
-          "to": "/docs/cloud-identity/v2/api-reference/users-operations/#add-user/",
+          "to": "/docs/cloud-identity/v2/api-reference/users-operations/",
           "rewrite": false,
           "status": 301
         },
         {
           "description": "Redirect common RBAC add role to user URL",
           "from": "^\\/docs\\/cloud-identity\\/v2\\/developer-guide\\/#add-role-to-user\\/?(.*)$",
-          "to": "/docs/cloud-identity/v2/api-reference/role-operations/#add-role-to-user/",
+          "to": "/docs/cloud-identity/v2/api-reference/role-operations/",
           "rewrite": false,
           "status": 301
         },
         {
           "description": "Redirect common RBAC delete global role from user URL",
           "from": "^\\/docs\\/cloud-identity\\/v2\\/developer-guide\\/#delete-global-role-from-user\\/?(.*)$",
-          "to": "/docs/cloud-identity/v2/api-reference/role-operations/#delete-global-role-from-user",
+          "to": "/docs/cloud-identity/v2/api-reference/role-operations/",
           "rewrite": false,
           "status": 301
         },
         {
             "description": "Redirect Identity Quickstart URL",
             "from": "^\\/docs\\/cloud-identity\\/v2\\/developer-guide#document-quickstart-guide\\/?(.*)$",
-            "to": "/docs/cloud-identity/v2/getting-started/#getting-started/$1",
+            "to": "/docs/cloud-identity/v2/getting-started/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect Identity developer-guide URL",
             "from": "^\\/docs\\/cloud-identity\\/v2\\/developer-guide\\/?(.*)$",
-            "to": "/docs/cloud-identity/v2/$1",
+            "to": "/docs/cloud-identity/v2/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect load balancers v1 developer-guide URL",
             "from": "^\\/docs\\/cloud-load-balancers\\/v1\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-load-balancers/v1/$1",
+            "to": "/docs/cloud-load-balancers/v1/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect load balancers v2 developer-guide URL",
             "from": "^\\/docs\\/cloud-load-balancers\\/v2\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-load-balancers/v2/$1",
+            "to": "/docs/cloud-load-balancers/v2/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect servers developer-guide URL",
             "from": "^\\/docs\\/cloud-servers\\/v2\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-servers/v2/$1",
+            "to": "/docs/cloud-servers/v2/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect first gen servers developer-guide URL",
             "from": "^\\/docs\\/cloud-servers\\/v1.0\\/cs-devguide\\/(.*?)",
-            "to": "/docs/cloud-servers/v2/$1",
+            "to": "/docs/cloud-servers/v2/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect images developer-guide URL",
             "from": "^\\/docs\\/cloud-images\\/v2\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-images/v2/$1",
+            "to": "/docs/cloud-images/v2/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect Cloud Block Storage developer-guide URL",
             "from": "^\\/docs\\/cloud-block-storage\\/v1\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-block-storage/v1/$1",
+            "to": "/docs/cloud-block-storage/v1/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect Cloud Backup v1 developer-guide URL",
             "from": "^\\/docs\\/cloud-backup\\/v1\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-backup/v1/$1",
+            "to": "/docs/cloud-backup/v1/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect Cloud Backup v2 developer-guide URL",
             "from": "^\\/docs\\/cloud-backup\\/v2\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-backup/v2/$1",
+            "to": "/docs/cloud-backup/v2/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect Cloud Databases developer-guide URL",
             "from": "^\\/docs\\/cloud-databases\\/v1\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-databases/v1/$1",
+            "to": "/docs/cloud-databases/v1/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect Cloud Files developer-guide URL",
             "from": "^\\/docs\\/cloud-files\\/v1\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-files/v1/$1",
+            "to": "/docs/cloud-files/v1/",
             "rewrite": false,
             "status": 301
         },
         {
-            "description": "Redirect Cloud Keep Getting Started reference from product bulletin",
-            "from": "^\\/docs\\/cloud-keep\\/v1\\/developer-guide\\/#document-getting-started\\/(.*?)",
-            "to": "/docs/cloud-keep/v1/getting-started/$1",
-            "rewrite": false,
-            "status": 301
-        },
-        {
-            "description": "Redirect Cloud Keep developer-guide URL",
-            "from": "^\\/docs\\/cloud-keep\\/v1\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-keep/v1/$1",
+            "description": "Redirect deprecated Cloud Keep links to docs page",
+            "from": "^\\/docs\\/cloud-keep\\/v1\\/(.*?)",
+            "to": "/docs/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect Cloud Queues developer-guide URL",
             "from": "^\\/docs\\/cloud-queues\\/v1\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-queues/v1/$1",
+            "to": "/docs/cloud-queues/v1/",
             "rewrite": false,
             "status": 301
         },
         {
             "from": "^\\/docs\\/cloud-metrics\\/v1\\/developer-guide\\/?(.*)$",
-            "to": "/docs/metrics/v1/$1",
+            "to": "/docs/metrics/v1/",
             "rewrite": false,
             "status": 301
         },
         {
             "from": "^\\/docs\\/cloud-metrics\\/v2\\/developer-guide\\/?(.*)$",
-            "to": "/docs/metrics/v2/$1",
+            "to": "/docs/metrics/v2/",
             "rewrite": false,
             "status": 301
         },
 
         {   "description": "Redirect Rackspace Monitoring developer-guide URL",
             "from": "^\\/docs\\/rackspace-monitoring\\/v1\\/developer-guide\\/?(.*)$",
-            "to": "/docs/rackspace-monitoring/v1/$1",
+            "to": "/docs/rackspace-monitoring/v1/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect Cloud Networks developer-guide URL",
             "from": "^\\/docs\\/cloud-networks\\/v1\\/developer-guide\\/?(.*)$",
-            "to": "/docs/cloud-networks/v2/$1",
+            "to": "/docs/cloud-networks/v2/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect Cloud Networks v2 developer-guide URL",
             "from": "^\\/docs\\/cloud-networks\\/v2\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-networks/v2/$1",
+            "to": "/docs/cloud-networks/v2/",
             "rewrite": false,
             "status": 301
         },
         {
             "description": "Redirect orchestration developer-guide URL",
             "from": "^\\/docs\\/cloud-orchestration\\/v1\\/developer-guide\\/(.*?)",
-            "to": "/docs/cloud-orchestration/v1/$1",
+            "to": "/docs/cloud-orchestration/v1/",
             "rewrite": false,
             "status": 301
         },
         {
           "description": "Redirect vCenter doc to URL for Managed VMWare services",
           "from": "^\\/docs/private-cloud\\/dedicated-vcloud\\/vcenter-handbook\\/?(.*)$",
-          "to": "/docs/managed-vmware-services/vcenter/$1",
+          "to": "/docs/managed-vmware-services/vcenter/",
           "rewrite": false,
           "status": 301
         },
         {
           "description": "Redirect vCloud v1.5 doc to URL for Managed VMWare services",
           "from": "^\\/docs\\/private-cloud\\/dedicated-vcloud\\/vcloud-handbook-v1.5\\/?(.*)$",
-          "to": "/docs/managed-vmware-services/vcloud/v1.5/?(.*)$",
+          "to": "/docs/managed-vmware-services/vcloud/v1.5/",
           "rewrite": false,
           "status": 301
         },
         {
           "description": "Redirect vCloud v1.0 doc to URL for managed VMWare services",
           "from": "^\\/docs\\/private-cloud\\/dedicated-vcloud\\/vcloud-handbook\\/?(.*)$",
-          "to": "/docs/managed-vmware-services/vcloud/v1//$1",
+          "to": "/docs/managed-vmware-services/vcloud/v1/",
           "rewrite": false,
           "status": 301
         },
         {
           "description": "Redirect dedicated vCloud doc menu to managed VMWare services menu",
           "from": "^\\/docs\\/private-cloud\\/dedicated-vcloud\\/?(.*)$",
-          "to": "/docs/#docs-managed-vmware-services",
+          "to": "/docs/",
           "rewrite": false,
           "status": 301
         },


### PR DESCRIPTION
Fix incorrect redirects found as a result of https://github.com/rackerlabs/rackspace-how-to/issues/1764

- Remove incorrect "replace string" from API Guide redirects
- Redirect depracated Cloud Keep API links to docs page
- Remove # link patterns in target URLs; not supported by presenter