### PR TITLE
redirect redundant wordpress article

### DIFF
--- a/config/rewrites.d/support.rackspace.com.json
+++ b/config/rewrites.d/support.rackspace.com.json
@@ -575,6 +575,13 @@
         "to": "/how-to/article-retired/",
         "rewrite": false,
         "status": 301
+      },
+      {
+        "description": "Redirect redundant WordPress article",
+        "from": "^\\/how-to\\/accelerating-wordpress-with-cloud-files-cdn-and-the-w3-total-cache-plugin(.*)$",
+        "to": "/how-to/configure-w3-total-cache-for-wordpress-with-rackspace-cloud-files-cdn/",
+        "rewrite": false,
+        "status": 301
       }
     ]
 }


### PR DESCRIPTION
Retiring redundant article and so this redirect will send traffic to the one we're keeping.