### PR TITLE
redirect retired article

### DIFF
--- a/config/rewrites.d/support.rackspace.com.json
+++ b/config/rewrites.d/support.rackspace.com.json
@@ -582,6 +582,13 @@
         "to": "/how-to/configure-w3-total-cache-for-wordpress-with-rackspace-cloud-files-cdn/",
         "rewrite": false,
         "status": 301
+      },
+      {
+        "description": "Retire Migrate your Drupal database from Cloud Sites to Cloud Servers",
+        "from": "^\\/how-to\\/migrating-your-drupal-database-to-cloud-servers(.*)$",
+        "to": "/how-to/article-retired/",
+        "rewrite": false,
+        "status": 301
       }
     ]
 }


### PR DESCRIPTION
Redirect retired Sites migration article to article-retired/

Part of https://github.com/rackerlabs/rackspace-how-to/issues/1807