### PR TITLE
Redirect RPC Ops Guide traffic to upstream

### DIFF
--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -313,6 +313,13 @@
           "status": 301
         },
         {
+          "description": "Redirect RPC Ops URL to OpenStack Ops Guide",
+          "from": "^/docs/private-cloud/rpc/([a-zA-Z0-9%_-]*)/rpc-ops/?(.*)$",
+          "to": "https://docs.openstack.org/ops-guide/index.html",
+          "rewrite:": false,
+          "status": 301
+        },
+        {
           "description": "Redirect RPC URL to current version",
           "from": "^/docs/private-cloud/rpc/?$",
           "to": "/docs/private-cloud/rpc/v13",


### PR DESCRIPTION
The external RPC Operations Guide is removed and combined with the
internal (RAX network or VPN access only) RPC Operations Guide.
External readers should be redirected to the upstream OpenStack
Operations Guide.

Connects https://github.com/rackerlabs/docs-rpc/issues/828