### PR TITLE
Removing Cloud Big Data from Dev Doc landing page.

### DIFF
--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -21,7 +21,6 @@
           "/docs/rackconnect/v3/developer-guide/": "https://github.com/rackerlabs/docs-cloud-rackconnect/",
           "/docs/cloud-queues/v1/": "https://github.com/rackerlabs/docs-cloud-queues/",
           "/docs/cloud-networks/v2/": "https://github.com/rackerlabs/docs-cloud-networks/",
-          "/docs/cloud-big-data/v2/": "https://github.com/rackerlabs/docs-cloud-big-data/v2/",
           "/docs/autoscale/v1/developer-guide/": "https://github.com/rackerlabs/otter/",
           "/docs/cloud-servers/v2/": "https://github.com/rackerlabs/docs-cloud-servers/",
           "/docs/cloud-files/v1/": "https://github.com/rackerlabs/docs-cloud-files/",

--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -75,12 +75,12 @@
           "rewrite": false,
           "status": 301
         },
-       {
-          "description": "Redirect cloud big data developer-guide URL",
-          "from": "^\\/docs\\/cloud-big-data\\/v2\\/developer-guide\\/(.*?)",
-          "to": "/docs/cloud-big-data/v2/",
-          "rewrite": false,
-          "status": 301
+        {
+            "description": "Redirect retired Cloud Big Data links to docs page",
+            "from": "^\\/docs\\/cloud-big-data\\/v2\\/(.*?)",
+            "to": "/docs/",
+            "rewrite": false,
+            "status": 301
         },
         {
           "description": "Redirect cloud dns developer-guide URL",

--- a/config/routes.d/developer.rackspace.com.json
+++ b/config/routes.d/developer.rackspace.com.json
@@ -29,7 +29,6 @@
             "^/docs/rackconnect/v3/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-queues/v1/": "user-guide.html",
             "^/docs/cloud-networks/v2/": "user-guide.html",
-            "^/docs/cloud-big-data/v2/": "user-guide.html",
             "^/docs/autoscale/v1/developer-guide": "docs-singlepage.html",
             "^/docs/cloud-servers/v2/": "user-guide.html",
             "^/docs/cloud-files/v1/": "user-guide.html",


### PR DESCRIPTION
partially closes H2 issue 1976

Removed from developer.com routes.d file
Redirect Big Data API to main docs page in rewrites.d
Removed from content.d file

I'm sure I'm missing steps....