### PR TITLE
INFODEV-293 Fix RPC staging

### DIFF
--- a/config/content.d/staging.horse.json
+++ b/config/content.d/staging.horse.json
@@ -1,8 +1,7 @@
 {
   "staging.horse": {
     "content": {
-      "/docs/private-cloud/rpc/eng-handbook/": "https://github.com/rackerlabs/docs-rpc/eng-handbook/",
-      "/docs/private-cloud/rpc/master/": "https://github.com/rackerlabs/docs-rpc/master/",
+      "/docs/private-cloud/rpc/master/": "https://github.com/rcbops/privatecloud-docs/master/",
       "/docs/private-cloud/release-notes/": "https://github.com/rcbops/rpc-openstack/master/",
       "/docs/api-doc-template/": "https://github.com/rackerlabs/docs-common/",
       "/docs/billing-api/": "https://github.com/rackerlabs/docs-billing-apiguide/"


### PR DESCRIPTION
RPC repo moved - update path
Remove deprecated handbook path (it's now in IX)