### PR TITLE
INFODEV-293 Remove handbook from routes

### DIFF
--- a/config/routes.d/staging.horse.json
+++ b/config/routes.d/staging.horse.json
@@ -2,7 +2,6 @@
   "staging.horse": {
     "routes": {
       "^/docs/private-cloud/release-notes/": "developer.rackspace.com/docs-singlepage.html",
-      "^/docs/private-cloud/rpc/eng-handbook/": "developer.rackspace.com/docs-singlepage.html",
       "^/docs/private-cloud/": "developer.rackspace.com/user-guide.html",
       "^/docs/api-doc-template/": "developer.rackspace.com/user-guide.html",
       "^/docs/billing-api/": "developer.rackspace.com/user-guide.html"


### PR DESCRIPTION
Deprecated RPC handbook (now in IX repo). This routes entry also needs
excised.