### PR TITLE
patching dependencies until node fix complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-deconst-assets": "0.2.1",
     "jquery": "^2.1.4",
-    "lodash": "^3.9.3"
+    "lodash": "^3.9.3",
+    "request": "<=2.81.0"
   },
   "dependencies": {
     "angular-cookies": "^1.4.7",
@@ -42,6 +43,7 @@
     "event-emitter": "^0.3.4",
     "grunt": "^0.4.5",
     "markalytics": "^0.1.3",
-    "url-parse": "^1.1.1"
+    "url-parse": "^1.1.1",
+    "request": "<=2.81.0"
   }
 }


### PR DESCRIPTION
Updates upstream have broken the nexus-control build. Pinning dependencies until testing complete on fully upgraded node versions. Local testing ran cleanly.