### PR TITLE
Remove getting-started redirect

### DIFF
--- a/config/rewrites.d/developer.rackspace.com.json
+++ b/config/rewrites.d/developer.rackspace.com.json
@@ -333,12 +333,5 @@
           "rewrite:": false,
           "status": 301
         },
-        {
-          "description": "Redirect getting started URLs to quickstart content",
-          "from": "^\\/docs\\/([^/]+?)\\/getting-started\\/(.*?)",
-          "to": "/docs/$1/quickstart/$2",
-          "rewrite": false,
-          "status": 301
-        }
     ]
 }


### PR DESCRIPTION
As Cat found out when creating a new doc project, this stanza will
redirect nearly *any* content matching `getting-started` to
`quickstart`.