### PR TITLE
Add SDP to production, remove from staging.horse

### DIFF
--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -39,6 +39,7 @@
           "/docs/rpc-vmware/rpc-vmware-customer-handbook/": "https://github.com/rackerlabs/rpc-vmware/rpc-vmware-customer-handbook/",
           "/docs/private-cloud/red-hat/": "https://github.com/rackerlabs/docs-redhat-osp/",
           "/docs/rackspace-federation/": "https://github.com/rackerlabs/docs-rackspace-federation/",
+          "/docs/ticketing/": "https://github.com/rackerlabs/docs-SDP/",
           "/search/": null
       },
       "proxy": {

--- a/config/content.d/staging.horse.json
+++ b/config/content.d/staging.horse.json
@@ -5,7 +5,6 @@
       "/docs/private-cloud/release-notes/": "https://github.com/rcbops/rpc-openstack/master/",
       "/docs/api-doc-template/": "https://github.com/rackerlabs/docs-common/",
       "/docs/billing-api/": "https://github.com/rackerlabs/docs-billing-apiguide/",
-      "/docs/sdp/": "https://github.com/rackerlabs/docs-SDP/",
       "/docs/managed-vmware-services/server-virt-handbook/":"https://github.com/rackerlabs/rpc-vmware/server-virt-handbook/"
     }
   }

--- a/config/routes.d/developer.rackspace.com.json
+++ b/config/routes.d/developer.rackspace.com.json
@@ -43,6 +43,7 @@
             "^/docs/rpc-vmware/": "user-guide.html",
             "^/docs/rack-cli/": "rack-cli.html",
             "^/docs/rackspace-federation/": "user-guide.html",
+            "^/docs/ticketing/": "user-guide.html",
             "^/sdks": "sdks-home.html",
             "^/sdks/.+?": "sdks-page.html",
             "\\.xml$": "feed.xml",

--- a/config/routes.d/staging.horse.json
+++ b/config/routes.d/staging.horse.json
@@ -5,7 +5,6 @@
       "^/docs/private-cloud/": "developer.rackspace.com/user-guide.html",
       "^/docs/api-doc-template/": "developer.rackspace.com/user-guide.html",
       "^/docs/billing-api/": "developer.rackspace.com/user-guide.html",
-      "^/docs/sdp/": "developer.rackspace.com/user-guide.html",
       "^/docs/managed-vmware-services/server-virt-handbook/": "developer.rackspace.com/user-guide.html"
     }
   }


### PR DESCRIPTION
Prepping a production push of SDP docs (https://github.com/rackerlabs/docs-SDP/).

Please do not add these docs to the landing page, we would like to keep them unlisted at this time.

Also, we have updated the URL from /docs/sdp to docs/ticketing. Please let us know if a repo rename or additional reconfiguration is needed. Thanks!