### PR TITLE
Adding server virt handbook to dev.r.c.json

### DIFF
--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -35,6 +35,7 @@
           "/docs/managed-vmware-services/vcenter/": "https://github.com/rackerlabs/rpc-vmware/vcenter-handbook/",
           "/docs/managed-vmware-services/vcloud/v1/": "https://github.com/rackerlabs/rpc-vmware/vcloud-handbook/",
           "/docs/managed-vmware-services/vcloud/v1.5/": "https://github.com/rackerlabs/rpc-vmware/vcloud-handbook-v1.5/",
+          "/docs/managed-vmware-services/server-virt-handbook/": "https://github.com/rackerlabs/rpc-vmware/server-virt-handbook/",
           "/docs/rpc-vmware/rpc-vmware-customer-handbook/": "https://github.com/rackerlabs/rpc-vmware/rpc-vmware-customer-handbook/",
           "/docs/private-cloud/red-hat/": "https://github.com/rackerlabs/docs-redhat-osp/",
           "/docs/rackspace-federation/": "https://github.com/rackerlabs/docs-rackspace-federation/",


### PR DESCRIPTION
Preparing the server virt handbook for publishing. 
Already has been tracked to the staging files: https://github.com/rackerlabs/nexus-control/pull/781