### PR TITLE
Fix link to Style Guide - back up one level

### DIFF
--- a/templates/developer.rackspace.com/_includes/site-footer.html
+++ b/templates/developer.rackspace.com/_includes/site-footer.html
@@ -3,7 +3,7 @@
       <div class="docs-links">
         <h5>Docs</h5>
         <ul>
-          <li><a href="/docs/style-guide/quickstart/">Style Guide for Technical Content</a></li>
+          <li><a href="/docs/style-guide/">Style Guide for Technical Content</a></li>
           <li><a href="/docs/cloud-backup/v1/getting-started/">Cloud Backup</a></li>
           <li><a href="/docs/cloud-block-storage/getting-started/">Cloud Block Storage</a></li>
           <li><a href="/docs/cloud-databases/getting-started/">Cloud Databases</a></li>


### PR DESCRIPTION
Should start at Style Guide title and not Quickstart section