### PR TITLE
Update Kubernetes repository (staging)

### DIFF
--- a/config/content.d/staging.horse.json
+++ b/config/content.d/staging.horse.json
@@ -5,7 +5,7 @@
       "/docs/private-cloud/release-notes/": "https://github.com/rcbops/rpc-openstack/master/",
       "/docs/api-doc-template/": "https://github.com/rackerlabs/docs-common/",
       "/docs/billing-api/": "https://github.com/rackerlabs/docs-billing-apiguide/",
-      "/docs/managed-kubernetes/master/": "https://github.com/rcbops/kubernetes-installer/master/"
+      "/docs/managed-kubernetes/master/": "https://github.com/rcbops/mk8s/master/"
     }
   }
 }

--- a/content-repositories.json
+++ b/content-repositories.json
@@ -5,7 +5,7 @@
   { "kind": "github", "project": "rackerlabs/docs-redhat-osp" },
   { "kind": "github", "project": "rcbops/privatecloud-docs", "branches": ["master", "v12", "v13", "v14", "v16"] },
   { "kind": "github", "project": "rcbops/rpc-openstack", "branches": ["master", "mitaka-13.0"] },
-  { "kind": "github", "project": "rcbops/kubernetes-installer", "branches": ["master"] },
+  { "kind": "github", "project": "rcbops/mk8s", "branches": ["master"] },
   { "kind": "github", "project": "rackerlabs/rackspace-how-to" },
   { "kind": "github", "project": "rackerlabs/docs-core-infra-user-guide" },
   { "kind": "github", "project": "rackerlabs/docs-cloud-backup" },


### PR DESCRIPTION
Rackspace KaaS docs were moved to a new repo. Therefore,
I'm adjusting the path to the repository to enable docs preview in
the new repository.