### PR TITLE
Remove developer community and IRC links

### DIFF
--- a/templates/developer.rackspace.com/_includes/site-header.html
+++ b/templates/developer.rackspace.com/_includes/site-header.html
@@ -1,8 +1,7 @@
 <header class="site-header">
     <div class="header-links">
         <div class="header-links-container">
-            <div class="phone-chat-links">
-                
+            <div class="phone-chat-links">               
             </div>
             <ul class="portal-links">
                 <li class="btn-link sign-up">

--- a/templates/developer.rackspace.com/_includes/site-header.html
+++ b/templates/developer.rackspace.com/_includes/site-header.html
@@ -2,8 +2,6 @@
     <div class="header-links">
         <div class="header-links-container">
             <div class="phone-chat-links">
-                <span class="text-link">IRC on Freenode <a href="https://webchat.freenode.net/?channels=rackspace">#rackspace</a></span>
-                <span class="text-link developer-forum"><a href="http://community.rackspace.com/developers/default">developer forum</a></span>
             </div>
             <ul class="portal-links">
                 <li class="btn-link sign-up">

--- a/templates/developer.rackspace.com/_includes/site-header.html
+++ b/templates/developer.rackspace.com/_includes/site-header.html
@@ -2,6 +2,7 @@
     <div class="header-links">
         <div class="header-links-container">
             <div class="phone-chat-links">
+                
             </div>
             <ul class="portal-links">
                 <li class="btn-link sign-up">

--- a/templates/developer.rackspace.com/_includes/site-header.html
+++ b/templates/developer.rackspace.com/_includes/site-header.html
@@ -1,7 +1,12 @@
 <header class="site-header">
     <div class="header-links">
         <div class="header-links-container">
-            <div class="phone-chat-links">               
+            <div class="phone-chat-links">
+                <ul>
+                    <li><a href='tel:+18009614454'>US Support: 1-800-961-4454</a></li>
+                    <li><a href='tel:+08009880300'>UK Support: 0800-988-0300</a></li>
+                    <li><a href="https://www.rackspace.com/information/contactus#form">Email Us</a></li>
+                </ul>
             </div>
             <ul class="portal-links">
                 <li class="btn-link sign-up">


### PR DESCRIPTION
from page header

Developer link gives message that the page is no longer available.
No one is using IRC much at this point.