### PR TITLE
Adding new vmware cloud guide to staging

### DIFF
--- a/config/content.d/staging.horse.json
+++ b/config/content.d/staging.horse.json
@@ -4,7 +4,7 @@
       "/docs/private-cloud/rpc/master/": "https://github.com/rcbops/privatecloud-docs/master/",
       "/docs/private-cloud/release-notes/": "https://github.com/rcbops/rpc-openstack/master/",
       "/docs/api-doc-template/": "https://github.com/rackerlabs/docs-common/",
-      "/docs/mpc-hyper-v/hyper-v-handbook": "https://github.com/rackerlabs/mpc-hyper-v/hyper-v-handbook/"
+      "/docs/rpc-vmware/vmware-cloud": "https://github.com/rackerlabs/rpc-vmware/vmware-cloud/"
     }
   }
 }


### PR DESCRIPTION
Also removing MPC guide (Don't know why this isn't gone already?)