### PR TITLE
feat(banner): taking down the maintenance banner; maintenance complete

### DIFF
--- a/templates/developer.rackspace.com/_includes/site-header.html
+++ b/templates/developer.rackspace.com/_includes/site-header.html
@@ -22,7 +22,6 @@
         </div>
     </div>
     {% include "_includes/header-nav.html" %}
-    {% include "_includes/maintenance-banner.html" %}
     <div class="header-headline">
         <div class="header-headline-container">
             <{{ headlineTag }}>

--- a/templates/support.rackspace.com/_includes/header.html
+++ b/templates/support.rackspace.com/_includes/header.html
@@ -55,16 +55,6 @@
             </nav>
         </div>
     </div>
-    <div class="rax-support-maintenance-banner">
-      <div class="rax-support-maintenance-banner-container">
-        <svg xmlns="http://www.w3.org/2000/svg" focusable="false" viewBox="0 0 16 16">
-          <path id="hxPath" d="M14.832 13.3c.438.88-.016 1.697-.944 1.698C11.925 15.001 9.962 15 8 15c-1.973 0-3.944.002-5.914 0-.608 0-1.054-.39-1.084-.985a1.395 1.395 0 0 1 .145-.663C3.123 9.44 5.104 5.533 7.088 1.627c.2-.393.5-.634.925-.627.433.007.72.272.923.674 1.68 3.317 3.364 6.632 5.046 9.947.284.56.57 1.117.851 1.68zm-6.332.2c.275 0 .5-.225.5-.5v-1c0-.275-.225-.5-.5-.5h-1a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1zm.065-3c.268 0 .52-.249.507-.5l.175-5c.032-.299-.203-.5-.472-.5h-1.55a.48.48 0 0 0-.475.5l.148 5c.008.275.235.5.504.5h1.163z"></path>
-        </svg>
-        <p class="rax-support-maintenance-banner-content">
-          NOTICE: Rackspace Engineers will be performing a scheduled maintenance on the infrastructure for support.rackspace.com and developer.rackspace.com on October 23, 2018 and October 24, 2018. During this maintenance, both sites will be down for a few hours between 10:00 PM CDT and 8:00 AM CDT, and customers will not be able to access the How-To or the API documentation. If you have any questions or concerns in regard to this maintenance, please do not hesitate to contact a member of our support team.
-        </p>
-      </div>
-    </div>
     <div id='rax-support-banner-wrapper'>
         <div id='rax-support-banner-container'>
             <div class='rax-support-banner-utility rax-clearfix'>


### PR DESCRIPTION
Leaving the partial from dev.rack and CSS pre-rendering for both sites in place. No partial was used for support.rack (different style).