### PR TITLE
Add support for Canonical link tag if indicated in Front Matter

### DIFF
--- a/templates/developer.rackspace.com/_layouts/raw.html
+++ b/templates/developer.rackspace.com/_layouts/raw.html
@@ -22,6 +22,11 @@
             {% set cssUrl = deconst.assets.assets_dist_css_main_css %}
         {% endif %}
         <link rel="stylesheet" href="{{ cssUrl }}">
+
+        {% if deconst.content.envelope.meta.canonical %}
+        <link rel="canonical" href="{{ deconst.content.envelope.meta.canonical }}" />
+        {% endif %}
+
         {% include "_includes/gtm-script.html" %}
         {% block headScripts %}{% endblock %}
     {% endblock %}


### PR DESCRIPTION
This change will render a `<link rel="canonical" ... />` tag in the header if the `canonical` property specified in a blog post's Front Matter.

This is helpful in situations when content is published in multiple locations, which may be the case for a recent post of mine. See [rel="canonical" - Google Support](https://support.google.com/webmasters/answer/139066?hl=en) for further details.

I was not able to test this locally, unfortunately, as following the instructions in the README gives me the following error:

```bash
Ignoring CONTROL_REPO_URL in favor of CONTROL_REPO_HOST_PATH.
ENDPOINT | http://localhost:9001
PROD_CONTENT_URL | http://integrated_content_1:8080/
Python 2.7.10
PYTHON VERSION |
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 290, in load
    **kw)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
Unable to issue an API key.
```

However, the change is small enough that I hope someone with a functional local environment will be able to test it quickly or be able to 👍 by eyeballing it. As far as I can tell, it should only affect posts whose Front Matter contain a `canonical` property, which is currently none of them.