### PR TITLE
Add support for Cannonical link

### DIFF
--- a/templates/developer.rackspace.com/_layouts/raw.html
+++ b/templates/developer.rackspace.com/_layouts/raw.html
@@ -22,6 +22,11 @@
             {% set cssUrl = deconst.assets.assets_dist_css_main_css %}
         {% endif %}
         <link rel="stylesheet" href="{{ cssUrl }}">
+
+        {% if deconst.content.envelope.meta.canonical %}
+        <link rel="canonical" href="{{ deconst.content.envelope.meta.canonical }}" />
+        {% endif %}
+
         {% include "_includes/gtm-script.html" %}
         {% block headScripts %}{% endblock %}
     {% endblock %}


### PR DESCRIPTION
This change will render a <link rel="canonical"... /> tag
in the header if the canonical property specified in a blog post's
Front Matter.