### PR TITLE
fix(stub): removing stub of repo setup

### DIFF
--- a/content-repositories.json
+++ b/content-repositories.json
@@ -43,6 +43,5 @@
   { "kind": "github", "project": "rackerlabs/docs-ras-databases" },
   { "kind": "github", "project": "rackerlabs/mpc-hyper-v" },
   { "kind": "github", "project": "rackerlabs/docs-customer-service" },
-  { "kind": "github", "project": "rackerlabs/docs-billing-apiguide" },
-  { "kind": "github", "project": "rackerlabs/docs-starter-kit-external" }
+  { "kind": "github", "project": "rackerlabs/docs-billing-apiguide" }
 ]


### PR DESCRIPTION
half-done repo setup is breaking the build. pulling it out