### PR TITLE
Remove IRC link at top left corner

### DIFF
--- a/templates/developer.rackspace.com/_includes/site-header.html
+++ b/templates/developer.rackspace.com/_includes/site-header.html
@@ -2,7 +2,6 @@
     <div class="header-links">
         <div class="header-links-container">
             <div class="phone-chat-links">
-                <span class="text-link">Contact Us<a href="https://www.rackspace.com/information/contactus#form"</a></span>
             </div>
             <ul class="portal-links">
                 <li class="btn-link sign-up">

--- a/templates/developer.rackspace.com/_includes/site-header.html
+++ b/templates/developer.rackspace.com/_includes/site-header.html
@@ -2,7 +2,7 @@
     <div class="header-links">
         <div class="header-links-container">
             <div class="phone-chat-links">
-                <span class="text-link">IRC on Freenode <a href="https://webchat.freenode.net/?channels=rackspace">#rackspace</a></span>
+                <span class="text-link">Contact Us<a href="https://www.rackspace.com/information/contactus#form"</a></span>
             </div>
             <ul class="portal-links">
                 <li class="btn-link sign-up">


### PR DESCRIPTION
Removes IRC link at top left corner of developer.rackspace.com. The IRC channels at rackspace are no longer attended. 

This is a fix that works until this page is actually redesigned, which is supposed to be happening within the next quarter or so.