### PR TITLE
fixed icon text spacing

### DIFF
--- a/assets/support.rackspace.com/src/css/main.scss
+++ b/assets/support.rackspace.com/src/css/main.scss
@@ -592,7 +592,7 @@ a {
                 background-size: 35px 35px;
 
                 h4 {
-                    line-height: 11px;
+                    line-height: 16px;
 
                     a {
                         text-transform: uppercase;


### PR DESCRIPTION
The Icon text was overlapping because of the previous line-height change. This PR corrects the issue. 