### PR TITLE
mobile resonsiveness added to several landing pages

### DIFF
--- a/assets/support.rackspace.com/src/css/_sass/components/_page-sidebar.scss
+++ b/assets/support.rackspace.com/src/css/_sass/components/_page-sidebar.scss
@@ -102,3 +102,134 @@
         }
     }
 }
+.hamburger {
+  font-size: 26px;
+  line-height: 70px;
+  display: none;
+}
+#toggle {
+  display: none;
+}
+@media only screen and (max-width: 375px) {
+  .hamburger {
+    display: block;
+    cursor: pointer;
+    margin: 20px 10px 30px 10px;
+    height: 50px;
+    font-size: 50px;
+  }
+
+  .area {
+    max-width: 100%;
+    text-align: center;
+    display: none;
+    line-height: 1.8em;
+  }
+
+  .area a {
+    display: block;
+    border: 2px solid #3498DB;
+    margin: 0px 10px 0px 10px;
+  }
+
+  .button-wp {
+    display: none;
+  }
+
+  .sidebar h3 {
+    font-size: 1.5em;
+    margin: 20px 10px 20px 10px;
+  }
+  .home-link {
+      display: block;
+      margin-bottom: 20px;
+      padding: 20px 20px 20px 10px;
+      border-bottom: 1px solid #E1E1E1;
+  }
+  #toggle:checked + .area {
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 376px) and (max-width: 600px){
+  .hamburger {
+    display: block;
+    cursor: pointer;
+    margin: 25px 0px 25px 10px;
+    height: 60px;
+    font-size: 60px;
+  }
+
+  .area {
+    max-width: 100%;
+    text-align: center;
+    display: none;
+    line-height: 1.8em;
+  }
+
+  .area a {
+    display: block;
+    border: 2px solid #3498DB;
+    margin: 0px 10px 0px 10px;
+  }
+
+  .button-wp {
+    display: none;
+  }
+
+  .sidebar h3 {
+    font-size: 1.5em;
+    margin: 25px 0px 25px 10px;
+  }
+
+  .home-link {
+      display: block;
+      margin-bottom: 20px;
+      padding: 20px 20px 20px 10px;
+      border-bottom: 1px solid #E1E1E1;
+  }
+
+  #toggle:checked + .area {
+    display: block;
+  }
+}
+@media only screen and (min-width: 601px) and (max-width: 800px){
+  .hamburger {
+    display: block;
+    cursor: pointer;
+    margin: 25px 0px 25px 10px;
+    height: 60px;
+    font-size: 60px;
+  }
+
+  .area {
+    max-width: 100%;
+    text-align: center;
+    display: none;
+    line-height: 1.8em;
+  }
+
+  .area a {
+    display: block;
+    border: 2px solid #3498DB;
+    margin: 0;
+  }
+
+  .button-wp {
+    display: none;
+  }
+
+  .sidebar h3 {
+    font-size: 1.5em;
+    margin: 25px 10px 25px 10px;
+  }
+  .home-link {
+      display: block;
+      margin-bottom: 20px;
+      padding: 20px 20px 20px 10px;
+      border-bottom: 1px solid #E1E1E1;
+  }
+  #toggle:checked + .area {
+    display: block;
+  }
+}

--- a/assets/support.rackspace.com/src/css/_sass/components/_sticky.scss
+++ b/assets/support.rackspace.com/src/css/_sass/components/_sticky.scss
@@ -9,3 +9,18 @@
     top: 0px;
     z-index: 1;
 }
+
+@media screen and (max-width: 375px){
+
+  .sticky {
+    position: relative;
+    min-width: 40%;
+  }
+}
+@media screen and (min-width: 376px) and (max-width: 700px){
+
+  .sticky {
+    position: relative;
+    min-width: 40%;
+  }
+}

--- a/assets/support.rackspace.com/src/css/_sass/pages/_product-guide.scss
+++ b/assets/support.rackspace.com/src/css/_sass/pages/_product-guide.scss
@@ -9,10 +9,30 @@
         list-style: none;
         margin-left: 0;
 
-        &.meta {
+        .meta {
             font-size: 14px;
             font-family: $font-family-primary;
         }
-        &.breadcrumbs {font-size: 11px;}
-     }
+        .breadcrumbs {font-size: 11px;}
+    }
+}
+
+@media screen and (max-width: 400px){
+    .content.product-guide {
+
+        ul {
+            font-family: $font-family-secondary;
+            font-size: 16px;
+            line-height: 1.2em;
+            font-weight: 400;
+            list-style: none;
+            margin-left: 0;
+
+            .meta {
+                font-size: 1.2em;
+                font-family: $font-family-primary;
+            }
+            .breadcrumbs {font-size: 11px;}
+        }
+    }
 }

--- a/assets/support.rackspace.com/src/css/_sass/views/_skeleton.scss
+++ b/assets/support.rackspace.com/src/css/_sass/views/_skeleton.scss
@@ -21,10 +21,10 @@
 -------------------------------------------------- */
 .container {
     position: relative;
-    
+
     // width: 100%;
     // max-width: 980px; -- turned off responsiveness for now
-    
+
     width: 966px;
     margin: 0 auto;
     box-sizing: border-box;
@@ -36,14 +36,24 @@
     box-sizing: border-box;
 }
 
-/* For devices larger than 400px */
-@media (min-width: 400px) {
+/* For devices larger than 400px *//*
+@media screen and (min-width: 400px) and (max-width: 600px) {
   .container {
+    display: flex;
+    flex-wrap: wrap;
 //    width: 85%;
     padding: 0; }
 }
 
-/* For devices larger than 550px */
+@media (min-width: 601px) {
+  .container {
+    display: flex;
+    flex-wrap: wrap;
+//    width: 85%;
+    padding: 0; }
+}*/
+
+// For devices larger than 550px
 //@media (min-width: 550px) {
     // .container {width: 80%;}
   .column, .columns {margin-left: 4%;}
@@ -52,13 +62,45 @@
   .one.column,
   .one.columns                    { width: 4.66666666667%; }
   .two.columns                    { width: 13.3333333333%; }
+
+  // three.columns media queries set the column width and position of the page-sidebar element
   .three.columns                  { width: 22%;            }
   .four.columns                   { width: 30.6666666667%; }
   .five.columns                   { width: 39.3333333333%; }
   .six.columns                    { width: 48%;            }
   .seven.columns                  { width: 56.6666666667%; }
   .eight.columns                  { width: 65.3333333333%; }
-  .nine.columns                   { width: 74.0%;          }
+  // nine.columns media queries set the column width of the product landing pages and all aritcles pages
+
+  @media screen and (max-width: 375px){
+
+    .nine.columns {
+      max-width: 30%;
+      float: none;
+      text-align: left;
+    }
+  }
+  @media screen and (min-width: 376px) and (max-width: 700px){
+
+    .nine.columns {
+      max-width: 35%;
+      float: none;
+      text-align: left;
+    }
+  }
+  @media screen and (min-width: 701px) and (max-width: 980px){
+
+    .nine.columns {
+      max-width: 77%;
+      text-align: left;
+    }
+  }
+  @media screen and (min-width: 981px){
+
+    .nine.columns {
+      max-width: 74%;
+    }
+  }
   .ten.columns                    { width: 82.6666666667%; }
   .eleven.columns                 { width: 91.3333333333%; }
   .twelve.columns                 { width: 100%; margin-left: 0; }
@@ -68,7 +110,7 @@
 
   .one-half.column                { width: 48%; }
 
-  /* Offsets */
+  // Offsets
   .offset-by-one.column,
   .offset-by-one.columns          { margin-left: 8.66666666667%; }
   .offset-by-two.column,
@@ -100,7 +142,6 @@
   .offset-by-one-half.column,
   .offset-by-one-half.columns     { margin-left: 52%; }
 
-//}
 
 /* Clearing
 -------------------------------------------------- */
@@ -125,10 +166,8 @@ there.
 
 
 /* Larger than mobile */
-@media (min-width: 400px) {}
 
-/* Larger than phablet (also point when grid becomes active) */
-@media (min-width: 550px) {}
+
 
 /* Larger than tablet */
 @media (min-width: 750px) {}

--- a/templates/support.rackspace.com/_includes/product-nav.html
+++ b/templates/support.rackspace.com/_includes/product-nav.html
@@ -20,7 +20,8 @@
     {% set productURL = deconst.content.envelope.meta.product.replace(" ", "-").toLowerCase() %}
     {% set productURL = productURL.replace("rackspace-private-cloud", "rpc") %}
 {% endif %}
-
+<label class="hamburger" for="toggle">&#9776;</label>
+<input type="checkbox" id="toggle"/>
 <ul class="area">
   <li{% if pageType == "product" %} class="active"{% endif %}><a href="/how-to/{{ productURL + "/" }}">Introduction</a></li>
   <li{% if pageType == "faq" %} class="active"{% endif %}><a href="/how-to/{{ productURL + "-faq/" }}">FAQ</a></li>


### PR DESCRIPTION
I have added media queries to make the pages at support.rackspace.com/how-to/product/, support.rackspace.com/how-to/product-faq/ and support.rackspace.com/how-to/product-all-articles/ mobile responsive. 

Examples of these urls would be https://support.rackspace.com/how-to/rackspace-email/, https://support.rackspace.com/how-to/rackspace-email-faq/ and https://support.rackspace.com/how-to/rackspace-email-all-articles/. 

When the screen port is narrowed below the respect media query pixel limits, the elements between the header and footer should stack vertically and the sidebar should become a hamburger menu. 