### PR TITLE
Adjust padding and mobilbe behavior of header

### DIFF
--- a/assets/support.rackspace.com/src/css/_sass/components/_search-box.scss
+++ b/assets/support.rackspace.com/src/css/_sass/components/_search-box.scss
@@ -3,6 +3,7 @@
     // margin: 0;
     float: right;
     width: 580px;
+    /*padding: 24px 19px 23px 19px;*/
 
     @media only screen and (max-width: 375px) {
       width: 100%;
@@ -10,6 +11,10 @@
 
     @media only screen and (min-width: 376px) and (max-width: 600px) {
       width: 100%;
+    }
+    @media only screen and (min-width: 601px) {
+      padding: 0px 19px 10px 19px;
+      max-width: 55%
     }
 
     form {

--- a/assets/support.rackspace.com/src/css/_sass/views/_headerstyle.scss
+++ b/assets/support.rackspace.com/src/css/_sass/views/_headerstyle.scss
@@ -371,7 +371,7 @@ a {
         text-transform: uppercase;
         padding: 10px 19px 10px 19px;
 
-        @media only screen and (max-width: 375px) {
+        @media only screen and (max-width: 600px) {
           display: none;
         }
 

--- a/assets/support.rackspace.com/src/css/_sass/views/_headerstyle.scss
+++ b/assets/support.rackspace.com/src/css/_sass/views/_headerstyle.scss
@@ -16,7 +16,6 @@
   strong,
   ul {
     margin: 0;
-    padding: 0;
     border: 0;
     outline: 0;
     font-size: 100%;
@@ -370,6 +369,11 @@ a {
         font-size: 35px;
         font-weight: 300;
         text-transform: uppercase;
+        padding: 10px 19px 10px 19px;
+
+        @media only screen and (max-width: 375px) {
+          display: none;
+        }
 
         span {
           display: block;
@@ -383,6 +387,7 @@ a {
     #rax-support-search-container {
       float: right;
       width: 580px;
+      padding: 0;
 
       @media only screen and (max-width: 375px) {
         width: 100%;

--- a/templates/support.rackspace.com/_includes/header.html
+++ b/templates/support.rackspace.com/_includes/header.html
@@ -57,7 +57,7 @@
             <div class='rax-support-banner-utility rax-clearfix'>
                 <a href='https://support.rackspace.com'>
                     <aside id='rax-header-link'>
-                        <h1><span>Rackspace</span> Support Network</h1>
+                        <h1> Support Network</h1>
                     </aside>
                 </a>
                 <div class="search">


### PR DESCRIPTION
This change adjusts the padding of the "Support Network" link as well as the search bar so that they are not flush against the edges of the screen. Additionally "Support Network" should no longer display on screens <375px. 