### PR TITLE
mobile responsive changes

### DIFF
--- a/assets/support.rackspace.com/src/css/_sass/components/_sticky.scss
+++ b/assets/support.rackspace.com/src/css/_sass/components/_sticky.scss
@@ -14,13 +14,11 @@
 
   .sticky {
     position: relative;
-    min-width: 40%;
   }
 }
 @media screen and (min-width: 376px) and (max-width: 700px){
 
   .sticky {
     position: relative;
-    min-width: 40%;
   }
 }

--- a/assets/support.rackspace.com/src/css/_sass/pages/_homepage.scss
+++ b/assets/support.rackspace.com/src/css/_sass/pages/_homepage.scss
@@ -2,7 +2,7 @@
 
     .content.home {
         border-left: none;
-        padding: 0 0 0 0;
+        padding: 0 0 0 20px;
 
         h2 {
             font-size: 28px;

--- a/assets/support.rackspace.com/src/css/_sass/views/_pagecontent.scss
+++ b/assets/support.rackspace.com/src/css/_sass/views/_pagecontent.scss
@@ -2,10 +2,18 @@
 .nine.content {
     width: 77%; //Temp fix
 }
+@media screen and (max-width: 600px){
 
+  .nine.content {
+    width: 100%;
+  }
+  .content ul {
+    margin-left: 0;
+  }
+}
 .content {
     margin-left: 0;
-    padding: 35px 0 10px 40px;
+    padding: 35px 20px 10px 40px;
     font-family: $font-family-primary;
     color: #474747;
     border-left: 1px solid #ccc;
@@ -155,7 +163,11 @@
         list-style-type: circle;
         list-style-position: outside;
         margin-left: 20px;
-    }
+
+        @media screen and (max-width: 600px){
+          margin-left: 0;
+        }
+      }
 
     code {
         font-family: $font-family-code;

--- a/assets/support.rackspace.com/src/css/_sass/views/_pagecontent.scss
+++ b/assets/support.rackspace.com/src/css/_sass/views/_pagecontent.scss
@@ -7,9 +7,6 @@
   .nine.content {
     width: 100%;
   }
-  .content ul {
-    margin-left: 0;
-  }
 }
 .content {
     margin-left: 0;

--- a/assets/support.rackspace.com/src/css/_sass/views/_skeleton.scss
+++ b/assets/support.rackspace.com/src/css/_sass/views/_skeleton.scss
@@ -21,11 +21,7 @@
 -------------------------------------------------- */
 .container {
     position: relative;
-
-    // width: 100%;
-    // max-width: 980px; -- turned off responsiveness for now
-
-    width: 966px;
+    width: 100%;
     margin: 0 auto;
     box-sizing: border-box;
 }
@@ -65,6 +61,20 @@
 
   // three.columns media queries set the column width and position of the page-sidebar element
   .three.columns                  { width: 22%;            }
+
+  @media screen and (max-width: 600px){
+
+    .three.columns {
+      width: 100%;
+    }
+  }
+
+  @media screen and (min-width: 601px) and (max-width: 980px){
+
+    .three.columns {
+      max-width: 77%;
+    }
+  }
   .four.columns                   { width: 30.6666666667%; }
   .five.columns                   { width: 39.3333333333%; }
   .six.columns                    { width: 48%;            }
@@ -72,23 +82,15 @@
   .eight.columns                  { width: 65.3333333333%; }
   // nine.columns media queries set the column width of the product landing pages and all aritcles pages
 
-  @media screen and (max-width: 375px){
+  @media screen and (max-width: 600px){
 
     .nine.columns {
-      max-width: 30%;
-      float: none;
+      width: 100%;
       text-align: left;
     }
   }
-  @media screen and (min-width: 376px) and (max-width: 700px){
 
-    .nine.columns {
-      max-width: 35%;
-      float: none;
-      text-align: left;
-    }
-  }
-  @media screen and (min-width: 701px) and (max-width: 980px){
+  @media screen and (min-width: 601px) and (max-width: 980px){
 
     .nine.columns {
       max-width: 77%;

--- a/assets/support.rackspace.com/src/css/_sass/views/_skeleton.scss
+++ b/assets/support.rackspace.com/src/css/_sass/views/_skeleton.scss
@@ -21,9 +21,13 @@
 -------------------------------------------------- */
 .container {
     position: relative;
-    width: 100%;
+    width: 966px;
     margin: 0 auto;
     box-sizing: border-box;
+
+    @media screen and (max-width: 600px){
+        width: 100%;
+    }
 }
 
 .column, .columns {

--- a/templates/support.rackspace.com/home.html
+++ b/templates/support.rackspace.com/home.html
@@ -25,7 +25,7 @@
         <a href="/how-to/rackspace-email/">Rackspace Email</a>
         <a href="/how-to/office-365/">Microsoft Office 365</a>
         <a href="/how-to/rackspace-email-archiving/">Rackspace Email Archiving</a>
-        <a href="/how-to/microsoft-exchange/">Microsoft Exchange</a>
+        <a href="/how-to/exchange/">Microsoft Exchange</a>
       </div>
     </li>
 


### PR DESCRIPTION
site: support.rackspace.com

This change makes the body of article pages <600px and landing pages mobile responsive. 

Change validation steps:

1. navigate to support.rackspace.com/how-to/ on local test environment
2. Select a product like cloud office Rackspace email
3. Open browser dev tools and switch to responsive testing. Scale the screen below 600px. 

The body of the product landing page should be contained within the screen and you should not be able to scroll horizontally. 

4. Select a how-to article and repeat testing. 