### PR TITLE
600px accordion menu

### DIFF
--- a/assets/support.rackspace.com/src/css/_sass/pages/_homepage.scss
+++ b/assets/support.rackspace.com/src/css/_sass/pages/_homepage.scss
@@ -454,7 +454,7 @@
         display: block;
       }
       .menu {
-        max-width: 100%;
+        width: 100%;
         border-radius: 8px;
         overflow: hidden;
       }
@@ -465,9 +465,10 @@
       }
       .btn {
         display: block;
+        font-size: 1.2em;
         padding: 16px 20px;
-        background: #3498db;
-        color: white;
+        background: white;
+        color: #2A2A2A;
         position: relative;
         text-decoration: none;
       }
@@ -494,7 +495,83 @@
         display: block;
         padding: 16px 26px;
         color: white;
-        font-size: 14px;
+        font-size: 1.2em;
+        margin: 4px 0;
+        position: relative;
+        text-decoration: none;
+        text-transform: uppercase;
+      }
+      .smenu a:before {
+        content: "";
+        position: absolute;
+        width: 6px;
+        height: 100%;
+        background: #3498db;
+        left: 0;
+        top: 0;
+        transition: 0.3s;
+        opacity: 0;
+      }
+      .smenu a:hover:before{
+        opacity: 1;
+      }
+      .item:target .smenu {
+        max-height: 50em;
+      }
+      .content.home {
+        display: none;
+      }
+    }
+
+    @media only screen and (max-width: 600px){
+
+      .middle {
+        position: relative;
+        display: block;
+      }
+      .menu {
+        width: 100%;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      .item {
+        border-top: 1px solid #2980b9;
+        overflow: hidden;
+        list-style-type: none;
+      }
+      .btn {
+        display: block;
+        font-size: 1.2em;
+        padding: 26px 20px;
+        background: white;
+        color: #2A2A2A;
+        position: relative;
+        text-decoration: none;
+      }
+      .btn:before {
+        content: "";
+        position: absolute;
+        width: 14px;
+        height: 14px;
+        background: white;
+        left: 20px;
+        bottom: -7px;
+        transform: rotate(45deg);
+      }
+      .btn i {
+        margin-right: 10px;
+      }
+      .smenu{
+        background: #333;
+        overflow: hidden;
+        transition: max-height 0.3s;
+        max-height: 0;
+      }
+      .smenu a {
+        display: block;
+        padding: 16px 26px;
+        color: white;
+        font-size: 1.2em;
         margin: 4px 0;
         position: relative;
         text-decoration: none;


### PR DESCRIPTION
site: support.rackspace.com

This change converts the icons of support.rackspace.com/how-to/ into an accordion menu when the device screen width is <600px  and >375px . It also scales the font size and padding of the menu. It also changes the color from blue to black(helix #2A2A2A) and white. 

Change validation steps:

navigate to support.rackspace.com/how-to/ on local test environment
Open browser dev tools and switch to responsive testing. Scale the screen below 600px.
The icons and tabs should convert into a black and white accordion style menu.
