### PR TITLE
getting started button stylings

### DIFF
--- a/assets/support.rackspace.com/src/css/_sass/pages/_homepage.scss
+++ b/assets/support.rackspace.com/src/css/_sass/pages/_homepage.scss
@@ -327,12 +327,12 @@
                       padding: 12px 50px;
                       margin-top: 7px;
                       white-space: nowrap;
-                      width: 30%;
                       float: left;
+                      text-align: center;
 
 
                         &:hover {
-                            background: #499917;
+                            background: #3498DB;
                             color: #fff;
                         }
                     }

--- a/assets/support.rackspace.com/src/css/_sass/pages/_homepage.scss
+++ b/assets/support.rackspace.com/src/css/_sass/pages/_homepage.scss
@@ -70,16 +70,37 @@
             aside.cta {
                 text-align: left;
 
-                #email-button {
-                    border: 1px solid #3498DB;
-                    background: none;
-                    color: #3498DB;
-                    padding: 12px 50px;
-                    margin-top: 7px;
-                    white-space: nowrap;
+                #cloud-button {
+                  border: 1px solid #3498DB;
+                  background: none;
+                  color: #3498DB;
+                  padding: 15px 50px 15px 30px;
+                  margin-top: 7px;
+                  margin-bottom: 70px;
+                  white-space: nowrap;
+                  width: 35%;
+                  float: left;
+
 
                     &:hover {
-                        background: #3498DB;
+                        background: #499917;
+                        color: #fff;
+                    }
+                }
+                #hosted-button {
+                  border: 1px solid #3498DB;
+                  background: none;
+                  color: #3498DB;
+                  padding: 15px 30px 15px 50px;
+                  margin-top: 7px;
+                  margin-right: 20px;
+                  margin-bottom: 70px;
+                  white-space: nowrap;
+                  width: 35%;
+                  float: right;
+
+                    &:hover {
+                        background: #499917;
                         color: #fff;
                     }
                 }
@@ -298,12 +319,15 @@
                     text-align: right;
 
                     #email-button {
-                        border: 1px solid #499917;
-                        background: none;
-                        color: #499917;
-                        padding: 12px 50px;
-                        margin-top: 7px;
-                        white-space: nowrap;
+                      border: 1px solid #3498DB;
+                      background: none;
+                      color: #3498DB;
+                      padding: 12px 50px;
+                      margin-top: 7px;
+                      white-space: nowrap;
+                      width: 30%;
+                      float: left;
+
 
                         &:hover {
                             background: #499917;

--- a/assets/support.rackspace.com/src/css/_sass/pages/_homepage.scss
+++ b/assets/support.rackspace.com/src/css/_sass/pages/_homepage.scss
@@ -80,10 +80,11 @@
                   white-space: nowrap;
                   width: 35%;
                   float: left;
+                  text-align: center;
 
 
                     &:hover {
-                        background: #499917;
+                        background: #3498DB;
                         color: #fff;
                     }
                 }
@@ -98,9 +99,10 @@
                   white-space: nowrap;
                   width: 35%;
                   float: right;
+                  text-align: center;
 
                     &:hover {
-                        background: #499917;
+                        background: #3498DB;
                         color: #fff;
                     }
                 }

--- a/templates/support.rackspace.com/home.html
+++ b/templates/support.rackspace.com/home.html
@@ -7,6 +7,7 @@
       <a href="#getting-started" class="btn">Getting Started</a>
       <div class="smenu">
         <a href="/how-to/getting-started-with-public-cloud/">Getting started with Public Cloud </a>
+        <a href="/how-to/getting-started-with-hosted-email/">Getting started with Rackspace Hosted Email </a>
       </div>
     </li>
 


### PR DESCRIPTION
In order to test this locally you will have to apply the changes made in https://github.com/rackerlabs/rackspace-how-to/pull/3391 to your local rackspace-how-to repo when testing locally. 

This PR adds a class for the new Getting Started with Rackspace Hosted Email as well as changes styling for the buttons under the Getting started tab on support.rackspace.com/how-to/ . 

It also adds a Getting Started with Rackspace Hosted Email to the accordion menu under Getting Started when the device screen width is <600px. 