### PR TITLE
Added custom class for top links on landing page

### DIFF
--- a/assets/support.rackspace.com/src/css/_sass/pages/_landingpage.scss
+++ b/assets/support.rackspace.com/src/css/_sass/pages/_landingpage.scss
@@ -1,5 +1,12 @@
 h2.front-page-heading {
   text-align: center;
+  font-weight: 400;
+  color: #666;
+  font-size: 26px;
+  line-height: 18px;
+  padding-bottom: 10px;
+  padding-top: 30px;
+  margin: 0px 0 25px 0;
 }
 p.front-blurb {
   text-align: center;
@@ -20,10 +27,12 @@ a.front-link {
   width: 90%;
   &:link {
     text-align: center;
+    font-size: 1.2em;
     color: #1E82D7;
     text-decoration: none;
     .caret {
       color: #1E82D7;
+      padding-left: 6px;
     }
   }
   &:hover {
@@ -31,7 +40,40 @@ a.front-link {
     color: #fff;
     .caret {
       color: #fff;
-      padding-left: 8px;
+      padding-left: 10px;
+    }
+  }
+}
+// top-links and first-links allow you to customize the styling of the top two
+// buttons on support.rackspace.com landing page
+div.top-links {
+  height: 70px;
+  margin: 20px 0;
+  display: flex;
+}
+
+a.first-links {
+  display: inline-block;
+  border: 1px solid #1E82D7;
+  padding: 20px 35px;
+  position: relative;
+  width: 90%;
+  &:link {
+    text-align: center;
+    font-size: 1.2em;
+    color: #1E82D7;
+    text-decoration: none;
+    .caret {
+      color: #1E82D7;
+      padding-left: 6px;
+    }
+  }
+  &:hover {
+    background: #1E82D7;
+    color: #fff;
+    .caret {
+      color: #fff;
+      padding-left: 10px;
     }
   }
 }

--- a/templates/support.rackspace.com/deferred.html
+++ b/templates/support.rackspace.com/deferred.html
@@ -10,7 +10,6 @@
     <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,900' rel='stylesheet'1 type='text/css'>
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
     <link href="{{ cssUrl }}" rel="stylesheet">
-    <link rel="stylesheet"href="https://4c5f0f4824b5f0326df3-ba48d26ab4f3c4858b16738b454bedcc.ssl.cf1.rackcdn.com/includes/css/style2.css"/>
 
 
     <!-- Google Tag Manager -->
@@ -28,6 +27,10 @@
     <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
 
     <script src="{{ deconst.assets.assets_support_rackspace_com_dist_js_carousel_min_js }}"></script>
+    {#
+      Rackspace Intelligence expects this HTML comment to appear on the home page.
+      Don't remove it unless you want to have a bad time.
+    #}
     <!-- SITE-MONITORING-KEY: 6b824a55c911a52a  -->
 {% endblock %}
 


### PR DESCRIPTION
Changes made:

top-links div and first-links class added to _landingpage.scss to enable custom styling of the top two buttons on support.rackspace.com.

Removed the Rackspace Private Cloud Powered by Microsoft box because that content is gone.

Removed <link rel="stylesheet"href="https://4c5f0f4824b5f0326df3-ba48d26ab4f3c4858b16738b454bedcc.ssl.cf1.rackcdn.com/includes/css/style2.css"/> from nexus-control. I then refactored landingpage.scss to account for the styling lost in style2.scss. I did this because very little of style2.scss is actually being used and it is very confusing to work between several main style sheets.


Local testing:

Pull down this PR and #1094 locally.

Run script/add-assets /path/nexus-control
and script/add-jekyll /path/docs-support-network/ using the local deconst environment.

Open a browser and navigate to localhost.

Validation:

All buttons should have the same styling.