### PR TITLE
Added buy now CTA

### DIFF
--- a/assets/support.rackspace.com/src/css/_sass/components/_page-sidebar.scss
+++ b/assets/support.rackspace.com/src/css/_sass/components/_page-sidebar.scss
@@ -101,6 +101,27 @@
             i {margin-right: 10px;}
         }
     }
+    .button-cart {
+        a {
+            display: block;
+            border: 1px solid $color-kcblue;
+            padding: 12px 35px;
+            margin-bottom: 35px;
+            white-space: nowrap;
+            font-weight: 600;
+            text-align: center;
+            background-color: #5aaa28;
+            color: #fff;
+
+            &:hover {
+                background: $color-kcblue;
+                color: #fff;
+                text-decoration: none;
+            }
+
+            i {margin-right: 10px;}
+        }
+    }
 }
 .hamburger {
   font-size: 26px;
@@ -177,6 +198,10 @@
     display: none;
   }
 
+  .button-cart {
+    display: none;
+  }
+
   .sidebar h3 {
     font-size: 1.5em;
     margin: 25px 0px 25px 10px;
@@ -216,6 +241,10 @@
   }
 
   .button-wp {
+    display: none;
+  }
+
+  .button-cart {
     display: none;
   }
 

--- a/templates/support.rackspace.com/_includes/feedback-sidebar.html
+++ b/templates/support.rackspace.com/_includes/feedback-sidebar.html
@@ -3,3 +3,17 @@
       <p class="button-wp"><a href="{{ deconst.content.envelope.meta.github_edit_url }}"><i class="fa fa-github"></i>Edit this article</a></p>
    </div>
 {% endif %}
+
+{% set buyURL = deconst.content.envelope.meta.product_url %}
+
+    <div class="contributing-container">
+      <p class="button-cart">
+        {% if buyURL  == "exchange" or buyURL == "rackspace-email" or buyURL == "rackspace-email-archiving" or buyURL == "skype-for-business"%}
+          <a class="active" <a href="https://cart.rackspace.com/{{ "apps" }}">Buy Now</a>
+        {% elif buyURL  == "office-365"%}
+          <a class="active" <a href="https://cart.rackspace.com/{{ "office365" }}">Buy Now</a>
+        {% elif buyURL  != "dedicated-hosting"%}
+          <a class="active" <a href="https://cart.rackspace.com/{{ "cloud" }}">Buy Now</a>
+        {% endif %}
+      </p>
+    </div>

--- a/templates/support.rackspace.com/_includes/header.html
+++ b/templates/support.rackspace.com/_includes/header.html
@@ -32,7 +32,8 @@
                         <span class='rax-btn'>Buy Now</span>
                         <ul>
                             <li><a href="https://cart.rackspace.com/cloud">Rackspace Cloud</a></li>
-                            <li><a href="https://cart.rackspace.com/apps">Email &amp; Apps</a></li>
+                            <li><a href="https://cart.rackspace.com/apps/signups/chooseApps/rax:1">Rackspace Email</a></li>
+                            <li><a href="https://cart.rackspace.com/apps/signups/chooseApps/hex:1">Hosted Exchange</a></li>
                             <li><a href="https://cart.rackspace.com/aws">Fanatical Support for AWS</a></li>
                             <li><a href="https://cart.rackspace.com/gcp">Managed Google Cloud Platform</a></li>
                             <li><a href="https://cart.rackspace.com/office365">Office 365</a></li>


### PR DESCRIPTION
This pull request adds a Buy Now button to the support.rackspace.com sidebar. This button should link directly to the product cart of the product page you are on. This button should be green by default and blue when hovering cursor over the button.

Ex. If you are on a Rackspace Email page, the link should link to the Cloud Office cart. 

If you are on a Cloud Servers page, the link should link to the Cloud cart. 

Additionally I changed the rax-btn buy now dropdown to split Email & Apps into Rackspace Email and Hosted Exchange to match Rackspace.com.