### PR TITLE
Added tag IDs to buy now button

### DIFF
--- a/templates/support.rackspace.com/_includes/feedback-sidebar.html
+++ b/templates/support.rackspace.com/_includes/feedback-sidebar.html
@@ -9,11 +9,11 @@
     <div class="contributing-container">
       <p class="button-cart">
         {% if buyURL  == "exchange" or buyURL == "rackspace-email" or buyURL == "rackspace-email-archiving" or buyURL == "skype-for-business"%}
-          <a class="active" <a href="https://cart.rackspace.com/{{ "apps" }}">Buy Now</a>
+          <a class="active" id="side-apps" href="https://cart.rackspace.com/{{ "apps" }}">Buy Now</a>
         {% elif buyURL  == "office-365"%}
-          <a class="active" <a href="https://cart.rackspace.com/{{ "office365" }}">Buy Now</a>
+          <a class="active" id="side-office" href="https://cart.rackspace.com/{{ "office365" }}">Buy Now</a>
         {% elif buyURL  != "dedicated-hosting"%}
-          <a class="active" <a href="https://cart.rackspace.com/{{ "cloud" }}">Buy Now</a>
+          <a class="active" id="side-cloud" href="https://cart.rackspace.com/{{ "cloud" }}">Buy Now</a>
         {% endif %}
       </p>
     </div>


### PR DESCRIPTION
This change allows analytics reporting to identify exactly which buttons are clicked on a page. This has been tested locally. 