### PR TITLE
Cta button

### DIFF
--- a/assets/src/css/less/typography.less
+++ b/assets/src/css/less/typography.less
@@ -51,6 +51,33 @@ a {
     &:visited {
         color: @link-color;
     }
+
+    &.cta {
+    border-radius: 1px;
+    display: inline-block;
+    padding: 1em 3em;
+    color: #fff;
+    text-decoration: none;
+    text-align: center;
+    .transition(background 0.1s ease-in-out);
+
+      &.red {
+        background: @cta-red;
+      }
+
+      &.blue {
+        background: @cta-blue;
+      }
+
+      &.purple {
+        background: @cta-purple;
+      }
+
+      &.teal {
+        background: @cta-teal;
+      }
+
+    }
 }
 
 p {

--- a/assets/src/css/less/variables.less
+++ b/assets/src/css/less/variables.less
@@ -31,6 +31,11 @@
 @theme-purple: #8e708e;
 @theme-pink: #d86c90;
 
+@cta-red: #eb0000;
+@cta-purple: #95098a;
+@cta-blue: #005ac8;
+@cta-teal: #00bebc;
+
 
 // Deconst-ified asset paths
 @assets_dist_fonts_sourcecodepro_regular_webfont_eot: '../fonts/sourcecodepro-regular-webfont.eot';


### PR DESCRIPTION
Creates a button class for a CTA link to be used primarily in the blogs.

Called as an 'a' class, for example:

`<a class="cta red" href="https://www.rackspace.com/application-management/professional-services">Learn more about Rackspace Application Services</a>`

which produces output such as:

![Screen Shot 2020-02-03 at 10 46 21 AM](https://user-images.githubusercontent.com/12717324/73672471-8a603b80-4672-11ea-9c27-948afb5c28c0.png)

The color options are red, blue, purple, and teal.