### PR TITLE
add templates and routes for txt and xml

### DIFF
--- a/config/routes.d/support-revs.staging.deconst.org.json
+++ b/config/routes.d/support-revs.staging.deconst.org.json
@@ -2,6 +2,8 @@
     "support-revs.staging.deconst.org": {
       "routes": {
         "^/": "support.rackspace.com/deferred.html",
+        "\\.xml$": "feed.xml",
+        "\\.txt$": "robots.txt",
         "^/how-to/$": "support.rackspace.com/home.html",
         "^/how-to/.+?": "support.rackspace.com/article.html",
         "^/how-to/cloud-servers/$": "support.rackspace.com/product.html",

--- a/config/routes.d/support.rackspace.com.json
+++ b/config/routes.d/support.rackspace.com.json
@@ -2,6 +2,8 @@
     "support.rackspace.com": {
       "routes": {
         "^/": "deferred.html",
+        "\\.xml$": "feed.xml",
+        "\\.txt$": "robots.txt",
         "^/how-to/$": "home.html",
         "^/how-to/.+?": "article.html",
         "^/how-to/cloud-servers/$": "product.html",

--- a/config/routes.d/support.staging.deconst.org.json
+++ b/config/routes.d/support.staging.deconst.org.json
@@ -2,6 +2,8 @@
     "support.staging.deconst.org": {
       "routes": {
         "^/": "support.rackspace.com/deferred.html",
+        "\\.xml$": "feed.xml",
+        "\\.txt$": "robots.txt",
         "^/how-to/$": "support.rackspace.com/home.html",
         "^/how-to/.+?": "support.rackspace.com/article.html",
         "^/how-to/cloud-servers/$": "support.rackspace.com/product.html",

--- a/config/routes.d/support.test.deconst.org.json
+++ b/config/routes.d/support.test.deconst.org.json
@@ -2,6 +2,8 @@
     "support.test.deconst.org": {
       "routes": {
         "^/": "support.rackspace.com/deferred.html",
+        "\\.xml$": "feed.xml",
+        "\\.txt$": "robots.txt",
         "^/how-to/$": "support.rackspace.com/home.html",
         "^/how-to/.+?": "support.rackspace.com/article.html",
         "^/how-to/cloud-servers/$": "support.rackspace.com/product.html",

--- a/templates/support.rackspace.com/feed.xml
+++ b/templates/support.rackspace.com/feed.xml
@@ -1,0 +1,2 @@
+{{ deconst.content.envelope.body }}
+{% set contentType = deconst.response.set('Content-Type', 'text/xml') %}

--- a/templates/support.rackspace.com/robots.txt
+++ b/templates/support.rackspace.com/robots.txt
@@ -1,0 +1,2 @@
+{{ deconst.content.envelope.body }}
+{% set contentType = deconst.response.set('Content-Type', 'text/plain') %}


### PR DESCRIPTION
Add templates and routes for files formated as `.txt` and `.xml` so that the HTML page header doesn't get included on the file.