### PR TITLE
updated copyright years for support/developer sites

### DIFF
--- a/templates/developer.rackspace.com/_includes/site-footer.html
+++ b/templates/developer.rackspace.com/_includes/site-footer.html
@@ -52,12 +52,12 @@
           <li><a href="https://blog.rackspace.com/">Rackspace Blog</a></li>
         </ul>
       </div>
-      <span class="copyright">&copy;2019 Rackspace US, Inc.</span>
+      <span class="copyright">&copy;2020 Rackspace US, Inc.</span>
     </div>
 </footer>
     <div class="basement-container">
         <ul>
-          <li><span>&copy;2019 Rackspace US, Inc.</span></li>
+          <li><span>&copy;2020 Rackspace US, Inc.</span></li>
           <li class="text-link"><a href="http://www.rackspace.com/about/">About Rackspace</a></li>
           <li class="text-link"><a href="http://ir.rackspace.com/">Investors</a></li>
           <li class="text-link"><a href="https://jobs.jobvite.com/rackspace/">Careers</a></li>

--- a/templates/developer.rackspace.com/common/footer.hbs
+++ b/templates/developer.rackspace.com/common/footer.hbs
@@ -2,7 +2,7 @@
     <div class="container">
         <img src="{{ assets.build_images_rackerpowered_logo_png }}" alt="Racker Powered">
         <ul>
-            <li>©2019 Rackspace, US Inc.</li>
+            <li>©2020 Rackspace, US Inc.</li>
             <li><a href="http://www.rackspace.com/about/">About Rackspace</a></li>
             <li><a href="http://ir.rackspace.com/">Investors</a></li>
             <li><a href="https://jobs.jobvite.com/rackspace/">Careers</a></li>

--- a/templates/support.rackspace.com/_includes/footer.html
+++ b/templates/support.rackspace.com/_includes/footer.html
@@ -46,7 +46,7 @@
     </div>
     <div id="rax-basement-wrapper">
         <div id="rax-basement-container" class="rax-clearfix">
-            <p>&copy; 2019 Rackspace US, Inc.</p>
+            <p>&copy; 2020 Rackspace US, Inc.</p>
         </div>
     </div>
 </div>

--- a/templates/support.rackspace.com/_includes/legal-footer.html
+++ b/templates/support.rackspace.com/_includes/legal-footer.html
@@ -1,5 +1,5 @@
 <div class="legal-container">
-  <p>&copy;2019 Rackspace US, Inc.</p>
+  <p>&copy;2020 Rackspace US, Inc.</p>
   <p>Except where otherwise noted, content on this site is licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License</p>
 
   <img src="https://licensebuttons.net/l/by-nc-nd/3.0/88x31.png" alt="" />


### PR DESCRIPTION
This change updates the Rackspace copyright year from 2019 to 2020 for developer.rackspace.com and support.rackspace.com. I tested changes for both sites locally. 