### PR TITLE
update mobile header css for solve blog

### DIFF
--- a/assets/src/css/less/modules/site-header.less
+++ b/assets/src/css/less/modules/site-header.less
@@ -232,6 +232,11 @@
                     margin-left: -0.25em;
                     position: relative;
 
+                    @media (max-width: 500px) {
+                      display: block;
+                      text-align: center;
+                    }
+
                     & > a {
                         .open-sans('bold');
                         color: #fff;
@@ -255,6 +260,10 @@
                     //should display dropdown when menu item is hovered over
                     &:hover ul {
                         display: block;
+
+                        @media (max-width: 500px) {
+                          position: relative;
+                        }
                     }
 
                     & > ul {
@@ -272,6 +281,10 @@
                             width: 220px;
                             border-radius: 4px;
 
+                            @media (max-width: 500px) {
+                              width: 100%;
+                            }
+
                             & > a {
                                 .open-sans('bold');
                                 color: rgb(103, 103, 129);
@@ -284,6 +297,10 @@
                                 &:hover {
                                     display: block;
                                     color: #fff;
+                                }
+
+                                @media (max-width: 500px){
+                                  text-align: center;
                                 }
                             }
                         }

--- a/templates/developer.rackspace.com/_includes/header-nav.html
+++ b/templates/developer.rackspace.com/_includes/header-nav.html
@@ -23,7 +23,10 @@
                         <a href="/blog/">Technical Blog</a>
                     </li>
                     <li>
-                        <a href="https://blog.rackspace.com">Rackspace Blog</a>
+                        <a href="https://rackspace.com/blog/">Rackspace Blog</a>
+                    </li>
+                    <li>
+                        <a href="https://rackspace.com/solve/">Solve: Thought Leadership</a>
                     </li>
                 </ul>
             </li>

--- a/templates/support.rackspace.com/_includes/header.html
+++ b/templates/support.rackspace.com/_includes/header.html
@@ -59,8 +59,9 @@
                     <li><a id='raxhs-api' href='https://developer.rackspace.com/docs'>Developer Documentation</a></li>
                     <li><a href="#">Blogs &#9660;</a>
                         <ul>
-                            <li><a href='https://developer.rackspace.com/blog/'> Technical Blog</a></li>
-                            <li><a href='https://blog.rackspace.com'>Rackspace Blog</a></li>
+                            <li><a href='https://developer.rackspace.com/blog/'>Technical Blog</a></li>
+                            <li><a href='https://www.rackspace.com/blog/'>Rackspace Blog</a></li>
+                            <li><a href='https://www.rackspace.com/solve/'>Solve: Thought Leadership</a></li>
                         </ul>
                     </li>
                 </ul>


### PR DESCRIPTION
Adjust mobile header CSS for screens under 500px so that the Solve blog link doesn't bleed off the page.
Add solve blog and adjust blog dropdown for support and develop sites.
Replaces #1147