### PR TITLE
add font settings to td element

### DIFF
--- a/assets/support.rackspace.com/src/css/_sass/components/_utility-lists.scss
+++ b/assets/support.rackspace.com/src/css/_sass/components/_utility-lists.scss
@@ -26,6 +26,9 @@ table {
     th, td {
         padding: 10px;
         text-align: left;
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 1.2em;
     }
 
     code:last-child, pre:last-child, p:last-child, ul:last-child, ol:last-child {margin-bottom: 0;}


### PR DESCRIPTION
For some reason the tables are inheriting the wrong font settings from somewhere, so this PR adds the font styles manually into the `td` element.

https://support.rackspace.com/how-to/permissions-matrix-for-next-generation-cloud-servers/ has a table you can look at for testing. The text inside the table should match the styling for the text outside of the table.