### PR TITLE
Adding a proxy link for nexus for kaas resources outside of dev guide

### DIFF
--- a/config/content.d/developer-revs.staging.deconst.org.json
+++ b/config/content.d/developer-revs.staging.deconst.org.json
@@ -70,6 +70,7 @@
     "proxy": {
       "/favicon.ico": "https://c0e9a73362c5d06f19d6-b39ff74cb91d713ac1253c5ae00eaccb.ssl.cf1.rackcdn.com/UI/favicon/favicon.ico",
       "/product-news-feed": "https://blog.rackspace.com/feed/"
+      "/docs/rkaas/v3.1.x-containers/list.json": "https://kaas-public-resources-prod.s3.amazonaws.com/containers-3.1.x.json"
     }
   }
 }

--- a/config/content.d/developer-revs.staging.deconst.org.json
+++ b/config/content.d/developer-revs.staging.deconst.org.json
@@ -69,7 +69,7 @@
     },
     "proxy": {
       "/favicon.ico": "https://c0e9a73362c5d06f19d6-b39ff74cb91d713ac1253c5ae00eaccb.ssl.cf1.rackcdn.com/UI/favicon/favicon.ico",
-      "/product-news-feed": "https://blog.rackspace.com/feed/"
+      "/product-news-feed": "https://blog.rackspace.com/feed/",
       "/docs/rkaas/v3.1.x-containers/list.json": "https://kaas-public-resources-prod.s3.amazonaws.com/containers-3.1.x.json"
     }
   }

--- a/config/content.d/developer.rackspace.com.json
+++ b/config/content.d/developer.rackspace.com.json
@@ -69,7 +69,8 @@
     },
     "proxy": {
       "/favicon.ico": "https://c0e9a73362c5d06f19d6-b39ff74cb91d713ac1253c5ae00eaccb.ssl.cf1.rackcdn.com/UI/favicon/favicon.ico",
-      "/product-news-feed": "https://blog.rackspace.com/feed/"
+      "/product-news-feed": "https://blog.rackspace.com/feed/",
+      "/docs/rkaas/v3.1.x-containers/list.json": "https://kaas-public-resources-prod.s3.amazonaws.com/containers-3.1.x.json"
     }
   }
 }

--- a/config/content.d/developer.staging.deconst.org.json
+++ b/config/content.d/developer.staging.deconst.org.json
@@ -69,7 +69,8 @@
     },
     "proxy": {
       "/favicon.ico": "https://c0e9a73362c5d06f19d6-b39ff74cb91d713ac1253c5ae00eaccb.ssl.cf1.rackcdn.com/UI/favicon/favicon.ico",
-      "/product-news-feed": "https://blog.rackspace.com/feed/"
+      "/product-news-feed": "https://blog.rackspace.com/feed/",
+      "/docs/rkaas/v3.1.x-containers/list.json": "https://kaas-public-resources-prod.s3.amazonaws.com/containers-3.1.x.json"
     }
   }
 }

--- a/config/content.d/developer.test.deconst.org.json
+++ b/config/content.d/developer.test.deconst.org.json
@@ -69,7 +69,8 @@
       },
       "proxy": {
           "/favicon.ico": "https://c0e9a73362c5d06f19d6-b39ff74cb91d713ac1253c5ae00eaccb.ssl.cf1.rackcdn.com/UI/favicon/favicon.ico",
-          "/product-news-feed": "https://blog.rackspace.com/feed/"
+          "/product-news-feed": "https://blog.rackspace.com/feed/",
+          "/docs/rkaas/v3.1.x-containers/list.json": "https://kaas-public-resources-prod.s3.amazonaws.com/containers-3.1.x.json"
       }
   }
 }


### PR DESCRIPTION
This changes adds a new proxied documentation file to s3 at `/docs/rkaas/v3.1.x-containers/list.json`