### PR TITLE
updated CTA link

### DIFF
--- a/assets/src/css/less/pages/home.less
+++ b/assets/src/css/less/pages/home.less
@@ -83,7 +83,7 @@ body.home {
                   color: white;
                 }
             }
-            .gcp-campaign {
+            .general-campaign {
                 .open-sans();
                 .button('blue');
                 font-size: 16px;

--- a/assets/support.rackspace.com/src/css/_sass/pages/_landingpage.scss
+++ b/assets/support.rackspace.com/src/css/_sass/pages/_landingpage.scss
@@ -82,7 +82,7 @@ div.campaign-link {
   margin: 20px 0;
   padding-left: 20%;
 }
-a.gcp-campaign {
+a.general-campaign {
   display: inline-block;
   border: 1px solid #1E82D7;
   padding: 20px 35px;


### PR DESCRIPTION
Updating the GCP CTAs to use a general leads page link. This changes buttons on the support and developer landing pages. The changes can be tested using the pull request changes for those repos. 

https://github.com/rackerlabs/docs-developer-blog/pull/816 for developer and https://github.com/rackerlabs/docs-support-network/pull/39