### PR TITLE
add redirect for retired article

### DIFF
--- a/config/rewrites.d/support-revs.staging.deconst.org.json
+++ b/config/rewrites.d/support-revs.staging.deconst.org.json
@@ -1588,6 +1588,13 @@
          "to": "/how-to/article-retired/",
          "rewrite": false,
          "status": 301
+      },
+      {
+         "description": "Retire linux-htaccess-tips-and-tricks",
+         "from": "^\\/how-to\\/linux-htaccess-tips-and-tricks(.*)$",
+         "to": "/how-to/article-retired/",
+         "rewrite": false,
+         "status": 301
       }
     ]
 }

--- a/config/rewrites.d/support.rackspace.com.json
+++ b/config/rewrites.d/support.rackspace.com.json
@@ -1666,6 +1666,13 @@
          "to": "/how-to/article-retired/",
          "rewrite": false,
          "status": 301
+      },
+      {
+         "description": "Retire linux-htaccess-tips-and-tricks",
+         "from": "^\\/how-to\\/linux-htaccess-tips-and-tricks(.*)$",
+         "to": "/how-to/article-retired/",
+         "rewrite": false,
+         "status": 301
       }
     ]
 }

--- a/config/rewrites.d/support.staging.deconst.org.json
+++ b/config/rewrites.d/support.staging.deconst.org.json
@@ -1665,6 +1665,13 @@
          "to": "/how-to/article-retired/",
          "rewrite": false,
          "status": 301
+      },
+      {
+         "description": "Retire linux-htaccess-tips-and-tricks",
+         "from": "^\\/how-to\\/linux-htaccess-tips-and-tricks(.*)$",
+         "to": "/how-to/article-retired/",
+         "rewrite": false,
+         "status": 301
       }
     ]
 }

--- a/config/rewrites.d/support.test.deconst.org.json
+++ b/config/rewrites.d/support.test.deconst.org.json
@@ -1649,6 +1649,13 @@
          "to": "/how-to/article-retired/",
          "rewrite": false,
          "status": 301
+      },
+      {
+         "description": "Retire linux-htaccess-tips-and-tricks",
+         "from": "^\\/how-to\\/linux-htaccess-tips-and-tricks(.*)$",
+         "to": "/how-to/article-retired/",
+         "rewrite": false,
+         "status": 301
       }
    ]
 }


### PR DESCRIPTION
Goes with https://github.com/rackerlabs/rackspace-how-to/pull/3920

Retiring an article that's full of instructions for Cloud Sites users